### PR TITLE
Use explicitly defined names for HTTP status codes to solidify intended design pattern.

### DIFF
--- a/src/cr/chain_replication_service.cc
+++ b/src/cr/chain_replication_service.cc
@@ -1,12 +1,13 @@
 #include "cr/chain_replication_service.h"
 #include "hashing_utils.h"
+#include "status_codes.h"
 #include "cr/chain_replication_utils.h"
 namespace smf {
 namespace chains {
 future<smf::rpc_envelope> chain_replication_service::mput(
   smf::rpc_recv_typed_context<tx_multiput> &&puts) {
   smf::rpc_envelope e(nullptr);
-  e.set_status(501); // Not implemented
+  e.set_status(HTTP_STATUS_NOT_IMPLEMENTED); // 501
   return make_ready_future<smf::rpc_envelope>(std::move(e));
 }
 
@@ -14,7 +15,7 @@ future<smf::rpc_envelope>
 chain_replication_service::sput(smf::rpc_recv_typed_context<tx_put> &&put) {
   if(!put) {
     smf::rpc_envelope e(nullptr);
-    e.set_status(501); // Not implemented
+    e.set_status(HTTP_STATUS_NOT_IMPLEMENTED); // 501
     return make_ready_future<smf::rpc_envelope>(std::move(e));
   }
   auto core_to_handle = put_to_lcore(put.get());
@@ -25,12 +26,12 @@ chain_replication_service::sput(smf::rpc_recv_typed_context<tx_put> &&put) {
     // .handle_exception([](std::exception_ptr eptr) {
     //   LOG_ERROR("Error saving smf::chains::sput()");
     //   smf::rpc_envelope e(nullptr);
-    //   e.set_status(500);
+    //   e.set_status(HTTP_STATUS_INTERNAL_SERVICE_ERROR); // 500
     //   return make_ready_future<smf::rpc_envelope>(std::move(e));
     // })
     .then([] {
       smf::rpc_envelope e(nullptr);
-      e.set_status(200);
+      e.set_status(HTTP_STATUS_OK); // 200
       return make_ready_future<smf::rpc_envelope>(std::move(e));
     });
 }
@@ -38,7 +39,7 @@ chain_replication_service::sput(smf::rpc_recv_typed_context<tx_put> &&put) {
 future<smf::rpc_envelope> chain_replication_service::fetch(
   smf::rpc_recv_typed_context<tx_fetch_request> &&rec) {
   smf::rpc_envelope e(nullptr);
-  e.set_status(501); // Not implemented
+  e.set_status(HTTP_STATUS_NOT_IMPLEMENTED); // 501
   return make_ready_future<smf::rpc_envelope>(std::move(e));
 }
 } // end namespace chains

--- a/src/rpc/README.md
+++ b/src/rpc/README.md
@@ -81,7 +81,7 @@ class SmfStorage: public smf::rpc_service {
     smf::rpc_envelope e(nullptr);
     // Helpful for clients to set the status.
     // Typically follows HTTP style. Not imposed by smf whatsoever.
-    e.set_status(200);
+    e.set_status(HTTP_STATUS_OK); // 200
     return make_ready_future<smf::rpc_envelope>(std::move(e));
   }
 }; // end of service: SmfStorage

--- a/src/rpc/smf_gen/cpp_generator.cc
+++ b/src/rpc/smf_gen/cpp_generator.cc
@@ -167,7 +167,7 @@ void print_header_service_method(smf_printer *printer,
   printer->print(
     "// Helpful for clients to set the status.\n"
     "// Typically follows HTTP style. Not imposed by smf whatsoever.\n");
-  printer->print("e.set_status(501); // Not implemented\n");
+  printer->print("e.set_status(HTTP_STATUS_NOT_IMPLEMENTED); // 501\n");
   printer->print(
     "return make_ready_future<smf::rpc_envelope>(std::move(e));\n");
   printer->outdent();

--- a/src/rpc/status_codes.h
+++ b/src/rpc/status_codes.h
@@ -1,0 +1,81 @@
+#pragma once
+
+/// \brief RPC return codes (for now) will reuse the HTTP status codes
+///        for simplicity sake
+///
+
+/* Continue */
+#define HTTP_STATUS_CONTINUE 100
+/* Switching Protocols */
+#define HTTP_STATUS_SWITCHING_PROTOCOLS 101
+/* OK */
+#define HTTP_STATUS_OK 200
+/* Created */
+#define HTTP_STATUS_CREATED 201
+/* Accepted */
+#define HTTP_STATUS_ACCEPTED 202
+/* Non-Authoritative Information */
+#define HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION 203
+/* No Content */
+#define HTTP_STATUS_NO_CONTENT 204
+/* Reset Content */
+#define HTTP_STATUS_RESET_CONTENT 205
+/* Partial Content */
+#define HTTP_STATUS_PARTIAL_CONTENT 206
+/* Multiple Choices */
+#define HTTP_STATUS_MULTIPLE_CHOICES 300
+/* Moved Permanently */
+#define HTTP_STATUS_MOVED_PERMANENTLY 301
+/* Moved Temporarily */
+#define HTTP_STATUS_MOVED_TEMPORARILY 302
+/* See Other */
+#define HTTP_STATUS_SEE_OTHER 303
+/* Not Modified */
+#define HTTP_STATUS_NOT_MODIFIED 304
+/* Use Proxy */
+#define HTTP_STATUS_USE_PROXY 305
+/* Bad Request */
+#define HTTP_STATUS_BAD_REQUEST 400
+/* Unauthorized */
+#define HTTP_STATUS_UNAUTHORIZED 401
+/* Payment Required */
+#define HTTP_STATUS_PAYMENT_REQUIRED 402
+/* Forbidden */
+#define HTTP_STATUS_FORBIDDEN 403
+/* Not Found */
+#define HTTP_STATUS_NOT_FOUND 404
+/* Method Not Allowed */
+#define HTTP_STATUS_METHOD_NOT_ALLOWED 405
+/* Not Acceptable */
+#define HTTP_STATUS_NOT_ACCEPTABLE 406
+/* Proxy Authentication Required */
+#define HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED 407
+/* Request Time-out */
+#define HTTP_STATUS_REQUEST_TIME_OUT 408
+/* Conflict */
+#define HTTP_STATUS_CONFLICT 409
+/* Gone */
+#define HTTP_STATUS_GONE 410
+/* Length Required */
+#define HTTP_STATUS_LENGTH_REQUIRED 411
+/* Precondition Failed */
+#define HTTP_STATUS_PRECONDITION_FAILED 412
+/* Request Entity Too Large */
+#define HTTP_STATUS_REQUEST_ENTITY_TOO_LARGE 413
+/* Request-URI Too Large */
+#define HTTP_STATUS_REQUEST_URI_TOO_LARGE 414
+/* Unsupported Media Type */
+#define HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE 415
+/* Internal Server Error */
+#define HTTP_STATUS_INTERNAL_SERVER_ERROR 500
+/* Not Implemented */
+#define HTTP_STATUS_NOT_IMPLEMENTED 501
+/* Bad Gateway */
+#define HTTP_STATUS_BAD_GATEWAY 502
+/* Service Unavailable */
+#define HTTP_STATUS_SERVICE_UNAVAILABLE 503
+/* Gateway Time-out */
+#define HTTP_STATUS_GATEWAY_TIME_OUT 504
+/* HTTP Version not supported */
+#define HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED 505
+

--- a/src/rpc/templates/server.cc
+++ b/src/rpc/templates/server.cc
@@ -17,7 +17,7 @@ class storage_service : public smf_gen::fbs::rpc::SmfStorage {
   Get(smf::rpc_recv_typed_context<smf_gen::fbs::rpc::Request> &&rec) override {
     // smf::LOG_INFO("got payload {}", (char *)rec.get()->name()->data());
     smf::rpc_envelope e(nullptr);
-    e.set_status(200);
+    e.set_status(HTTP_STATUS_OK); // 200
     return make_ready_future<smf::rpc_envelope>(std::move(e));
   }
 };


### PR DESCRIPTION
I've added a header file with the HTTP status codes as defines so that methods can use the symbolic name rather than raw integers.  This change only serves to make explicit an implicit design pattern.  There is an argument that an enum might be better than a set of defines so as to have a type to check and debugging symbols.