### PR TITLE
wip:adding wal_fil_manager & wal_writer_file_lease

### DIFF
--- a/CMake/base_flags.cmake
+++ b/CMake/base_flags.cmake
@@ -1,6 +1,7 @@
 # Seastar doesn't finish linking w/ gold linker
 # "-fuse-ld=gold"
 set(BASE_FLAGS
+  "-fdiagnostics-color=auto"
   "-fPIC"
   "-fconcepts"
   "-Wall"

--- a/meta/playbooks/roles/american_fuzzy_lop/tasks/main.yml
+++ b/meta/playbooks/roles/american_fuzzy_lop/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+- unarchive:
+    src: "http://lcamtuf.coredump.cx/afl/releases/afl-2.39b.tgz"
+    copy: False
+    dest: '{{goobly_cache_dir}}/'
+    creates: '{{goobly_cache_dir}}/afl-2.39b'
+    remote_src: True
+
+- shell: "git init . && git add . && git commit -am buildsys"
+  args:
+    chdir: '{{goobly_cache_dir}}/afl-2.39b'
+    creates: '{{goobly_cache_dir}}/afl-2.39b/.git'
+
+- shell: "make install -j$((({{ansible_processor_vcpus}}-1))) PREFIX={{third_party_dir}}"
+  args:
+    chdir: '{{goobly_cache_dir}}/afl-2.39b'
+    creates: '{{third_party_dir}}/bin/afl-g++'

--- a/meta/playbooks/roles/seastar/tasks/main.yml
+++ b/meta/playbooks/roles/seastar/tasks/main.yml
@@ -43,14 +43,9 @@
     update=yes
     recursive=yes
     force=yes
-    version='7790e'
+    version='f07f8ed'
 
-# TODO(agallego): at HEAD as of Nov 27 2016, seastar's dpdk has
-# https://github.com/scylladb/seastar/issues/217
-# compilation issues. - enable later with old command - debug later
-# - command: ./configure.py --enable-dpdk
-#
-- command: ./configure.py
+- command: ./configure.py --enable-dpdk
   args:
     chdir: '{{goobly_cache_dir}}/seastar'
     creates: '{{goobly_cache_dir}}/seastar/build.ninja'

--- a/meta/playbooks/system_wide_deps.yml
+++ b/meta/playbooks/system_wide_deps.yml
@@ -4,3 +4,4 @@
   hosts: localhost
   roles:
     - compilation_tooling
+    - american_fuzzy_lop

--- a/misc/version.sh
+++ b/misc/version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+git_root=$(git rev-parse --show-toplevel)
+function print_smf_version() {
+    git_hash=$(git log -1 --pretty=format:"%H")
+    git_author=$(git log -1 --pretty=format:"%aN")
+    git_date=$(git log -1 --pretty=format:"%ai")
+    git_subject=$(git log -1 --pretty=format:"%s")
+
+    echo "#ifndef SMF_VERSION_H"
+    echo "#define SMF_VERSION_H"
+    echo
+    echo "static const char *kGitVersion = \"${git_hash}\";"
+    echo "static const char *kGitVersionAuthor = \"${git_author}\";"
+    echo "static const char *kGitVersionDate   = \"${git_date}\";"
+    echo "static const char *kGitVersionSubject ="
+    echo "  \"${git_subject}\";"
+    echo
+    echo "#endif"
+
+}
+
+print_smf_version > "${git_root}/src/version.h"

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+version.h

--- a/src/afl_tests/rpc/rpc.dict
+++ b/src/afl_tests/rpc/rpc.dict
@@ -1,0 +1,14 @@
+# Copyright (c) 2017 Alexander Gallego. All rights reserved.
+#
+#
+# AFL dictionary for smf RPC
+# --------------------------
+#
+# Several basic syntax elements and attributes, modeled on rpc.fbs.
+#
+#
+
+header_size="1"
+header_flags="1"
+header_checksum="1"
+payload="\x89\x0d\x0a\x1a\x0a"

--- a/src/filesystem/wal.h
+++ b/src/filesystem/wal.h
@@ -16,9 +16,9 @@ namespace smf {
 class wal_iface {
  public:
   /// \brief returns starting offset off a successful write
-  virtual future<uint64_t> append(wal_write_request req)           = 0;
-  virtual future<> invalidate(uint64_t epoch)                      = 0;
-  virtual future<wal_opts::maybe_buffer> get(wal_read_request req) = 0;
+  virtual future<uint64_t> append(wal_write_request req)          = 0;
+  virtual future<> invalidate(uint64_t epoch)                     = 0;
+  virtual future<wal_read_reply::maybe> get(wal_read_request req) = 0;
 
   // \brief filesystem monitoring
   virtual future<> open()  = 0;
@@ -51,7 +51,7 @@ class shardable_wal : public wal_iface {
   inline future<> invalidate(uint64_t epoch) final {
     return w_->invalidate(epoch);
   }
-  inline future<wal_opts::maybe_buffer> get(wal_read_request req) final {
+  inline future<wal_read_reply::maybe> get(wal_read_request req) final {
     return w_->get(std::move(req));
   }
   inline future<> open() final { return w_->open(); }

--- a/src/filesystem/wal_file_manager.cc
+++ b/src/filesystem/wal_file_manager.cc
@@ -1,0 +1,16 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#include "filesystem/wal_file_manager.h"
+
+namespace smf {
+wal_file_manager::wal_file_manager() {}
+wal_file_manager::~wal_file_manager() {}
+
+std::unique_ptr<wal_writer_file_lease> wal_file_manager::get_file_lease(
+  sstring filename, file_output_stream_options stream_otps) {}
+
+
+void wal_file_manager::set_compaction_period(
+  steady_clock_type::duration period = 100ms) {}
+
+}  // namespace smf

--- a/src/filesystem/wal_file_name_mender.h
+++ b/src/filesystem/wal_file_name_mender.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#pragma once
+#include <core/reactor.hh>
+// smf
+#include "filesystem/wal_file_walker.h"
+
+namespace smf {
+struct wal_file_name_mender : wal_file_walker {
+  wal_file_name_mender(file d) : wal_file_walker(std::move(d)) {}
+
+  future<> visit(directory_entry de) final {
+    if (is_name_locked(de)) {
+      return rename_file(de.name, name_without_prefix(de));
+    }
+    return make_ready_future<>();
+  }
+};
+
+}  // namespace smf

--- a/src/filesystem/wal_head_file_functor.h
+++ b/src/filesystem/wal_head_file_functor.h
@@ -37,16 +37,13 @@ struct wal_head_file_min_comparator {
 ///       });
 ///
 template <typename Comparator> struct wal_head_file_functor : wal_file_walker {
-  explicit wal_head_file_functor(file dir, sstring prefix = "smf")
-    : wal_file_walker(std::move(dir), std::move(prefix)) {}
-
+  explicit wal_head_file_functor(file dir) : wal_file_walker(std::move(dir)) {}
   future<> visit(directory_entry de) final {
     if (comparator(last_file, de.name)) {
       last_file = de.name;
     }
     return make_ready_future<>();
   }
-
   sstring    last_file;
   Comparator comparator{};
 };

--- a/src/filesystem/wal_impl_with_cache.h
+++ b/src/filesystem/wal_impl_with_cache.h
@@ -19,7 +19,7 @@ class wal_impl_with_cache : public wal {
   future<> open() final;
   future<> close() final;
 
-  future<wal_opts::maybe_buffer> get(wal_read_request req) final;
+  future<wal_read_reply::maybe> get(wal_read_request req) final;
 
  private:
   std::unique_ptr<wal_writer>    writer_ = nullptr;

--- a/src/filesystem/wal_mem_cache.h
+++ b/src/filesystem/wal_mem_cache.h
@@ -60,13 +60,13 @@ class wal_mem_cache {
     return make_ready_future<uint64_t>(virtual_offset);
   }
 
-  future<wal_opts::maybe_buffer> get(uint64_t offset) {
+  future<wal_read_reply::maybe> get(uint64_t offset) {
     auto it = puts_.find(offset);
     if (it != puts_.end()) {
       temporary_buffer<char> tmp(it->data.get(), it->data.size());
-      return make_ready_future<wal_opts::maybe_buffer>(std::move(tmp));
+      return make_ready_future<wal_read_reply::maybe>(std::move(tmp));
     }
-    return make_ready_future<wal_opts::maybe_buffer>();
+    return make_ready_future<wal_read_reply::maybe>();
   }
 
   /// brief - invalidates

--- a/src/filesystem/wal_name_extractor_utils.cc
+++ b/src/filesystem/wal_name_extractor_utils.cc
@@ -6,7 +6,7 @@
 namespace smf {
 
 uint64_t extract_epoch(const sstring &filename) {
-  static const re2::RE2 kFileNameEpochExtractorRE("[a-zA-Z\\d]+_(\\d+)\\.wal");
+  static const re2::RE2 kFileNameEpochExtractorRE("[:a-zA-Z\\d]+_(\\d+)\\.wal");
   uint64_t              retval = 0;
   re2::RE2::FullMatch(filename.c_str(), kFileNameEpochExtractorRE, &retval);
   return retval;

--- a/src/filesystem/wal_name_parser.h
+++ b/src/filesystem/wal_name_parser.h
@@ -4,21 +4,11 @@
 // third party
 #include <core/sstring.hh>
 #include <re2/re2.h>
-#include "log.h"
+
 
 namespace smf {
-static const re2::RE2 kFileNameRE("[a-zA-Z\\d]+_\\d+\\.wal");
-
+static const re2::RE2 kFileNameRE("[:a-zA-Z\\d]+_\\d+\\.wal");
 struct wal_name_parser {
-  explicit wal_name_parser(sstring _prefix = "smf") : prefix(_prefix) {
-    for (char c : prefix) {
-      LOG_THROW_IF(
-        (c == '\\' || c == '(' || c == ')' || c == '[' || c == ']'),
-        "wal_name_parser cannot include a prefix with special chars");
-    }
-  }
-  const sstring prefix;
-
   bool operator()(const sstring &filename) {
     return re2::RE2::FullMatch(filename.c_str(), kFileNameRE);
   }

--- a/src/filesystem/wal_opts.h
+++ b/src/filesystem/wal_opts.h
@@ -103,8 +103,6 @@ struct cache_stats {
 // this should probably be a sharded<wal_otps> &
 // like the tcp server no?
 struct wal_opts {
-  using maybe_buffer = std::experimental::optional<temporary_buffer<char>>;
-
   explicit wal_opts(sstring log_directory) : directory(log_directory) {}
   wal_opts(wal_opts &&o) noexcept : directory(std::move(o.directory)),
                                     cache_size(o.cache_size),

--- a/src/filesystem/wal_reader.h
+++ b/src/filesystem/wal_reader.h
@@ -15,7 +15,7 @@
 namespace smf {
 class wal_reader;
 struct wal_reader_visitor : wal_file_walker {
-  wal_reader_visitor(wal_reader *r, file dir, sstring prefix = "smf");
+  wal_reader_visitor(wal_reader *r, file dir);
   future<> visit(directory_entry wal_file_entry) final;
   wal_reader *reader;
 };
@@ -50,7 +50,7 @@ class wal_reader {
   future<> open();
   future<> close();
   /// brief - returns the next record in the log
-  future<wal_opts::maybe_buffer> get(wal_read_request req);
+  future<wal_read_reply::maybe> get(wal_read_request req);
 
   const sstring directory;
 

--- a/src/filesystem/wal_reader_node.h
+++ b/src/filesystem/wal_reader_node.h
@@ -24,7 +24,7 @@ class wal_reader_node {
   future<> close();
   future<> open();
 
-  future<wal_opts::maybe_buffer> get(wal_read_request r);
+  future<wal_read_reply::maybe> get(wal_read_request r);
 
   inline uint64_t file_size() { return io_->file_size; }
   inline uint64_t ending_epoch() const {

--- a/src/filesystem/wal_writer.cc
+++ b/src/filesystem/wal_writer.cc
@@ -36,7 +36,7 @@ future<> wal_writer::open_empty_dir(sstring prefix) {
   wal_writer_node_opts wo;
   wo.wstats = wstats_;
   wo.prefix = prefix + id;
-  writer_   = std::make_unique<wal_writer_node>(wo);
+  writer_   = std::make_unique<wal_writer_node>(std::move(wo));
   return writer_->open();
 }
 
@@ -63,9 +63,9 @@ future<> wal_writer::do_open() {
     auto l = make_lw_shared<wal_head_file_max_functor>(std::move(f));
     return l->close().then([l, this]() {
       if (l->last_file.empty()) {
-        return open_empty_dir(l->name_parser.prefix);
+        return open_empty_dir("smf");
       }
-      return open_non_empty_dir(l->last_file, l->name_parser.prefix);
+      return open_non_empty_dir(l->last_file, "smf");
     });
   });
 }

--- a/src/filesystem/wal_writer_file_lease.h
+++ b/src/filesystem/wal_writer_file_lease.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#pragma once
+#include <core/future.hh>
+
+namespace smf {
+/// \brief exposes what the \ref wal_writer_node.h
+/// needs which is effecitvely a output_stream<char>
+/// however, we want to prevent the readers and writers to be accessing the
+/// same files
+///
+class wal_writer_file_lease {
+ public:
+  virtual future<> close() = 0;
+  virtual future<> flush() = 0;
+  virtual future<> open()  = 0;
+  virtual future<> append(const char *buf, size_t n) = 0;
+  virtual ~wal_writer_file_lease() {}
+};
+}  // namespace smf

--- a/src/filesystem/wal_writer_file_lease_impl.h
+++ b/src/filesystem/wal_writer_file_lease_impl.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#pragma once
+#include "filesystem/wal_writer_file_lease.h"
+#include "log.h"
+
+namespace smf {
+
+/// \brief changes the filename while it's being written to:
+///   "core:<id>:locked:" + filename
+/// upon successful closing of the stream, it will rename it to the correct
+/// name. It is also open w/ exclusive acess. Any other thread accessing the
+/// file will fail/throw. Caller must ensure that only one filename is
+/// needed for writing at a time
+/// see \ref wal_file_manager.h
+///
+/// Rejected Solutions: Keep a pointer to the file_manager.
+///
+/// having a pointer to the file manager introduces unnecessary complexity,
+/// given that we have to monitor already the filesystem for files dropped
+/// by other cores etc.
+///
+/// The tradeoff here is that since we change the filename, we rely on the
+/// filesystem manger to "heal" the files. That is during startup,
+/// rename all the files that start w/ core:<id>:locked to remove the prefix.
+///
+class wal_writer_file_lease_impl : public virtual wal_writer_file_lease {
+ public:
+  wal_writer_file_lease_impl(sstring filename, file_output_stream_options opts)
+    : original_name_(filename), opts_(opts) {}
+  ~wal_writer_file_lease_impl() {
+    LOG_ERROR_IF(!closed_, "***DATA LOSS*** wal_file_lease was not closed. "
+                           "Orignal name {}, current name: {}",
+                 original_name_, lock_prefix() + original_name_);
+  }
+
+  future<> open() final {
+    auto name = lock_prefix() + original_name_;
+    // the file should fail if it exists. It should not exist on disk, as
+    // we'll truncate them
+    auto flags = open_flags::rw | open_flags::create | open_flags::truncate
+                 | open_flags::exclusive;
+
+    return open_file_dma(name, flags).then([this](file f) {
+      fstream_ = make_file_output_stream(std::move(f), opts_);
+      return make_ready_future<>();
+    });
+  }
+  future<> close() final {
+    closed_      = true;
+    auto current = lock_prefix() + original_name_;
+    auto real    = original_name_;
+    return fstream_.flush()
+      .then([this] { return fstream_.close(); })
+      .then([real, current] { return rename_file(current, real); });
+  }
+
+  future<> flush() final { return fstream_.flush(); }
+
+  future<> append(const char *buf, size_t n) final {
+    // TODO(agallego): add temporary_buffer<char>
+    // https://groups.google.com/forum/?hl=en#!topic/seastar-dev/SY-VG9xPVaY
+    // buffers need to be aligned on the filesystem
+    // so it's better if you let the underlying system copy
+    // them - pending my fix to merge upstream
+    return fstream_.write(buf, n);
+  }
+
+  static const sstring &lock_prefix() {
+    static thread_local const sstring id = to_sstring(engine().cpu_id());
+    static thread_local const sstring kCorePrefix = "core:" + id + "locked:";
+    return kCorePrefix;
+  }
+
+ private:
+  const sstring              original_name_;
+  file_output_stream_options opts_;
+  output_stream<char>        fstream_;
+  bool                       closed_{false};
+};
+
+}  // namespace smf

--- a/src/filesystem/wal_writer_node.h
+++ b/src/filesystem/wal_writer_node.h
@@ -8,8 +8,8 @@
 // smf
 #include "filesystem/wal_opts.h"
 #include "filesystem/wal_requests.h"
+#include "filesystem/wal_writer_file_lease.h"
 #include "filesystem/wal_writer_utils.h"
-
 
 namespace smf {
 // TODO(agallego) - use the stats internally now that you have them
@@ -32,7 +32,7 @@ struct wal_writer_node_opts {
 ///
 class wal_writer_node {
  public:
-  explicit wal_writer_node(wal_writer_node_opts opts);
+  explicit wal_writer_node(wal_writer_node_opts &&opts);
   /// \brief 0-copy append to buffer
   /// \return the starting offset on file for this put
   ///
@@ -69,10 +69,9 @@ class wal_writer_node {
   future<> pad_end_of_file();
 
  private:
-  wal_writer_node_opts opts_;
-  output_stream<char>  fstream_;
-  uint64_t             current_size_ = 0;
-  bool                 closed_       = false;
+  wal_writer_node_opts                   opts_;
+  uint64_t                               current_size_ = 0;
+  std::unique_ptr<wal_writer_file_lease> lease_        = nullptr;
 };
 
 }  // namespace smf

--- a/src/flatbuffers/rpc.fbs
+++ b/src/flatbuffers/rpc.fbs
@@ -8,10 +8,6 @@ namespace smf.fbs.rpc;
 enum Flags:uint (bit_flags) {
   /// \brief check the compressed payload if enabled.
   CHECKSUM,
-
-  /// uses flatbuffers schema verification
-  VERIFY_SCHEMA,
-
   /// \brief the payload is compressed using zstandrad 1.0
   ZSTD
 }

--- a/src/integration_tests/wal/main.cc
+++ b/src/integration_tests/wal/main.cc
@@ -66,9 +66,10 @@ int main(int args, char **argv, char **env) {
                                            uint32_t(0), p};
                   return x.get(std::move(rq)).then([i](auto read_result) {
                     assert(read_result);
-                    assert(read_result->size() == std::strlen(kPayload));
+                    auto size = read_result->fragments.front().data.size();
+                    assert(size == std::strlen(kPayload));
                     smf::DLOG_INFO("Got result from a read with size: {}",
-                                   read_result->size());
+                                   size);
                     reducible_append ra;
                     ra.v.insert(i);
                     return std::move(ra);

--- a/src/rpc/rpc_server_stats_printer.cc
+++ b/src/rpc/rpc_server_stats_printer.cc
@@ -11,7 +11,6 @@ rpc_server_stats_printer::rpc_server_stats_printer(
 
 void rpc_server_stats_printer::start() {
   timer_.set_callback([this] {
-    ++timer_callback_counter_;
     aggregate_stats().then(
       [this](rpc_server_stats stats) { LOG_INFO("{}", stats); });
   });

--- a/src/rpc/rpc_server_stats_printer.h
+++ b/src/rpc/rpc_server_stats_printer.h
@@ -24,7 +24,6 @@ class rpc_server_stats_printer {
 
  private:
   timer<>                        timer_;
-  uint32_t                       timer_callback_counter_{0};
   distributed<rpc_server_stats> *stats_;
   duration_t                     period_;
 };

--- a/src/test/wal_name_parser_tests/wal_name_re.cc
+++ b/src/test/wal_name_parser_tests/wal_name_re.cc
@@ -4,8 +4,8 @@
 #include "filesystem/wal_name_parser.h"
 
 TEST(wal_name_parser, basic) {
-  smf::wal_name_parser parser("smf");
-  ASSERT_TRUE(parser("smf0_0.wal"));
+  smf::wal_name_parser parser;
+  ASSERT_TRUE(parser("core:0:locked:smf0_0.wal"));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
* wal_writer_file_lease effectively takes a lease of a name
upon opening a file... it opens a DIFFERENT file. it opens it w/ an
exclusive lock, which is basically not needed at all... now that all the
writes are centralized...

so i don't need to add a prefix at all... it just needs to be
communicated w/ the file manager...

the readers can only read frofm the subscription of the file namanger...

also pending is the healing of the filesystem...

the good thing now is that this alows for a centralized point for adding
compactions, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/senior7515/smf/58)
<!-- Reviewable:end -->
