### PR TITLE
filesystem:clock_pro: add tests of wal_reader

### DIFF
--- a/src/filesystem/CMakeLists.txt
+++ b/src/filesystem/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library (smf_filesystem STATIC
   ${PROJECT_SOURCE_DIR}/src/filesystem/wal_name_extractor_utils.cc
   ${PROJECT_SOURCE_DIR}/src/filesystem/wal_name_extractor_utils.cc
   ${PROJECT_SOURCE_DIR}/src/filesystem/wal_writer_utils.cc
+  ${PROJECT_SOURCE_DIR}/src/filesystem/wal_pretty_print_utils.cc
   )
 
 # add_dependencies(smf_filesystem

--- a/src/filesystem/wal_clock_pro_cache.cc
+++ b/src/filesystem/wal_clock_pro_cache.cc
@@ -8,15 +8,25 @@
 #include <boost/iterator/counting_iterator.hpp>
 // smf
 #include "filesystem/file_size_utils.h"
+#include "filesystem/wal_pretty_print_utils.h"
+#include "hashing/hashing_utils.h"
 #include "platform/log.h"
 
 namespace smf {
 
+static uint32_t round_up(int64_t file_size, size_t alignment) {
+  uint32_t ret = file_size / alignment;
+  if (file_size % alignment != 0) {
+    ret += 1;
+  }
+  return ret;
+}
+
 wal_clock_pro_cache::wal_clock_pro_cache(lw_shared_ptr<file> f,
-                                         size_t              size,
+                                         int64_t             size,
                                          uint32_t max_pages_in_memory)
   : file_size(size)
-  , number_of_pages(std::ceil(file_size / f->disk_read_dma_alignment()))
+  , number_of_pages(round_up(file_size, f->disk_read_dma_alignment()))
   , file_(std::move(f)) {
   if (max_pages_in_memory == 0) {
     const auto percent     = uint32_t(number_of_pages * .10);
@@ -42,20 +52,7 @@ future<const wal_clock_pro_cache::cache_chunk *>
 wal_clock_pro_cache::clock_pro_get_page(uint32_t                 page,
                                         const io_priority_class &pc) {
   using ret_type = const cache_chunk *;
-  // first modification. The original algo assumes static working set.
-  // we fetch things dynamiclly. so just fill up the buffer before eviction
-  // agorithm kicks in. nothing fancy
-  //
-  // if we just let the clock-pro work w/out pre-allocating, you end up w/ one
-  // or 2 pages that you are moving between hot and cold and test
-  //
-  if (size() < number_of_pages) {
-    ++stats_.total_allocation;
-    return fetch_page(page, pc).then([this, page](auto chunk) {
-      mcold_.emplace_front(std::move(chunk));
-      return make_ready_future<ret_type>(mcold_.get_cache_chunk_ptr(page));
-    });
-  }
+
   // proper clock-pro starts here.
   if (mhot_.contains(page)) {
     ++stats_.hot_hits;
@@ -71,6 +68,22 @@ wal_clock_pro_cache::clock_pro_get_page(uint32_t                 page,
     c->ref = true;
     return make_ready_future<ret_type>(mcold_.get_cache_chunk_ptr(page));
   }
+
+  // first modification. The original algo assumes static working set.
+  // we fetch things dynamiclly. so just fill up the buffer before eviction
+  // agorithm kicks in. nothing fancy
+  //
+  // if we just let the clock-pro work w/out pre-allocating, you end up w/ one
+  // or 2 pages that you are moving between hot and cold and test
+  //
+  if (size() < number_of_pages) {
+    ++stats_.total_allocation;
+    return fetch_page(page, pc).then([this, page](auto chunk) {
+      mcold_.emplace_front(std::move(chunk));
+      return make_ready_future<ret_type>(mcold_.get_cache_chunk_ptr(page));
+    });
+  }
+
   // it's a miss. relclaim the first met cold page w/ ref bit to 0
   auto maybe_hot = mcold_.hand_cold();
 
@@ -103,74 +116,164 @@ wal_clock_pro_cache::clock_pro_get_page(uint32_t                 page,
 
 
 future<wal_clock_pro_cache::cache_chunk> wal_clock_pro_cache::fetch_page(
-  uint32_t page, const io_priority_class &pc) {
-  static const size_t kAlignment = file_->disk_read_dma_alignment();
-  return file_->dma_read_exactly<char>(page, kAlignment, pc)
-    .then([this, page](temporary_buffer<char> buf) {
-      cache_chunk c(page, std::move(buf));
+  const uint32_t &page, const io_priority_class &pc) {
+  static const uint64_t kAlignment = file_->disk_read_dma_alignment();
+  const uint64_t page_offset_begin = static_cast<uint64_t>(page) * kAlignment;
+
+  auto bufptr = allocate_aligned_buffer<char>(kAlignment, kAlignment);
+  auto fut = file_->dma_read(page_offset_begin, bufptr.get(), kAlignment, pc);
+
+  return std::move(fut).then(
+    [page, bufptr = std::move(bufptr)](auto size) mutable {
+      LOG_THROW_IF(size > kAlignment, "Read more than 1 page");
+      cache_chunk c(page, size, std::move(bufptr));
       return make_ready_future<wal_clock_pro_cache::cache_chunk>(std::move(c));
     });
 }
 
-bool wal_clock_pro_cache::fill(wal_read_reply *                        out,
-                               const wal_read_request &                r,
-                               const wal_clock_pro_cache::cache_chunk *chunk) {
-  static const auto kHeaderSize = sizeof(fbs::wal::wal_header);
-  static const auto kAlignment  = file_->disk_read_dma_alignment();
-  // bounds
-  auto       begin = r.offset % kAlignment;
-  auto const end   = begin + std::min(r.size - out->size(), chunk->data.size());
-  auto       begin_it_fn = [&]() { return chunk->data.get() + begin; };
-  // check if we are not at the right page
-  if (chunk->page != offset_to_page(r.offset + out->size(), kAlignment)) {
-    return false;
-  }
-  while (begin < end) {
-    if (begin + kHeaderSize > end) {
-      // ensure space for copying header from page
-      return false;
+static uint64_t copy_page_data(temporary_buffer<char> *                buf,
+                               const int64_t &                         offset,
+                               const int64_t &                         size,
+                               const wal_clock_pro_cache::cache_chunk *chunk,
+                               const size_t &alignment) {
+  LOG_THROW_IF(chunk->buf_size == 0, "Bad page");
+  const int64_t bottom_page_offset = offset > 0 ? offset % alignment : 0;
+  const int64_t buffer_offset =
+    bottom_page_offset > 0 ? (bottom_page_offset % (chunk->buf_size)) : 0;
+
+  const char *   begin_src = chunk->data.get() + buffer_offset;
+  char *         begin_dst = buf->get_write() + (buf->size() - size);
+  const uint64_t step_size =
+    std::min<int64_t>(chunk->buf_size - buffer_offset, size);
+  const char *end_src = begin_src + step_size;
+
+  LOG_THROW_IF(step_size == 0, "Invalid range to copy. step: {}", step_size);
+  std::copy(begin_src, end_src, begin_dst);
+  return step_size;
+}
+
+future<temporary_buffer<char>> wal_clock_pro_cache::read_exactly(
+  int64_t offset, int64_t size, const io_priority_class &pc) {
+  struct buf_req {
+    buf_req(int64_t _offset, int64_t _size, const io_priority_class &p)
+      : offset(_offset), size(_size), pc(p) {}
+
+    void update_step(uint64_t step) {
+      size -= step;
+      offset += step;
     }
-    // get the header
-    fbs::wal::wal_header hdr;
-    auto                 hdr_ptr = reinterpret_cast<char *>(&hdr);
-    std::copy(begin_it_fn(), begin_it_fn() + kHeaderSize, hdr_ptr);
-    // update for header and check again if size
-    begin += kHeaderSize;
-    if (begin + hdr.size() > end) {
-      // no space for body
-      return false;
-    }
-    temporary_buffer<char> buf(hdr.size());
-    std::copy(begin_it_fn(), begin_it_fn() + hdr.size(), buf.get_write());
-    begin += hdr.size();
-    wal_read_reply::fragment f(hdr, std::move(buf));
-    out->fragments.emplace_back(std::move(f));
-  }
-  return true;
+
+    int64_t                  offset;
+    int64_t                  size;
+    const io_priority_class &pc;
+  };
+  static const size_t kAlignment = file_->disk_read_dma_alignment();
+  auto                buf        = make_lw_shared<temporary_buffer<char>>(size);
+  auto                req        = make_lw_shared<buf_req>(offset, size, pc);
+  auto                max_pages  = 1 + (req->size / kAlignment);
+  LOG_THROW_IF(max_pages > number_of_pages,
+               "Request asked to read more pages, than available on disk");
+  return repeat([buf, this, req]() mutable {
+           auto page = offset_to_page(req->offset, kAlignment);
+           return this->clock_pro_get_page(page, req->pc)
+             .then([buf, req](auto chunk) {
+               if (req->size <= 0) {
+                 return stop_iteration::yes;
+               }
+               auto step = copy_page_data(buf.get(), req->offset, req->size,
+                                          chunk, kAlignment);
+               req->update_step(step);
+               return stop_iteration::no;
+             });
+         })
+    .then([buf] {
+      return make_ready_future<temporary_buffer<char>>(buf->share());
+    });
 }
 
 future<wal_read_reply> wal_clock_pro_cache::read(wal_read_request r) {
+  return this->do_read(r).then([](auto ret) {
+    wal_read_reply reply;
+    reply.emplace_back(ret->move_fragments());
+    return make_ready_future<wal_read_reply>(std::move(reply));
+  });
+}
+
+static void validate_header(const fbs::wal::wal_header &hdr,
+                            const int64_t &             file_size) {
+  LOG_THROW_IF(hdr.flags() == 0 || hdr.checksum() == 0 || hdr.size() == 0,
+               "Could not read header from file");
+  LOG_THROW_IF(hdr.size() > file_size,
+               "Header asked for more data than file_size. Header:{}", hdr);
+}
+
+static fbs::wal::wal_header get_header(const temporary_buffer<char> &buf) {
+  static const uint32_t kHeaderSize = sizeof(fbs::wal::wal_header);
+  fbs::wal::wal_header  hdr;
+  LOG_THROW_IF(buf.size() < kHeaderSize, "Could not read header. Only read",
+               buf.size());
+  char *hdr_ptr = reinterpret_cast<char *>(&hdr);
+  std::copy(buf.get(), buf.get() + kHeaderSize, hdr_ptr);
+  return hdr;
+}
+
+static void validate_payload(const fbs::wal::wal_header &  hdr,
+                             const temporary_buffer<char> &buf) {
+  LOG_THROW_IF(buf.size() != hdr.size(), "Could not read header. Only read",
+               buf.size());
+  uint32_t checksum = xxhash_32(buf.get(), buf.size());
+  LOG_THROW_IF(checksum != hdr.checksum(),
+               "bad header: {}, missmatching checksums. "
+               "expected checksum: {}",
+               hdr, checksum);
+}
+
+future<lw_shared_ptr<wal_read_reply>> wal_clock_pro_cache::do_read(
+  wal_read_request r) {
+  using ret_type = lw_shared_ptr<wal_read_reply>;
   LOG_THROW_IF(r.offset + r.size > file_size,
                "Expected normalized offsets. Invalid range."
                "see wal_reader_node.cc?");
-  static const auto kAlignment      = file_->disk_read_dma_alignment();
-  const uint64_t    number_of_pages = r.size / kAlignment;
-  auto              ret             = make_lw_shared<wal_read_reply>();
-  return do_for_each(boost::counting_iterator<int>(0),
-                     boost::counting_iterator<int>(number_of_pages),
-                     [this, r, ret](int page_idx) mutable {
-                       auto next_offset = r.offset + (page_idx * kAlignment);
-                       auto page = offset_to_page(next_offset, kAlignment);
-                       return clock_pro_get_page(page, r.pc)
-                         .then([this, r, ret](const cache_chunk *ptr) mutable {
-                           this->fill(ret.get(), r, ptr);
-                           return make_ready_future<>();
-                         });
-                     })
-    .then([ret] {
-      wal_read_reply reply;
-      reply.fragments = std::move(ret->fragments);
-      return make_ready_future<wal_read_reply>(std::move(reply));
-    });
+  static const uint32_t kHeaderSize = sizeof(fbs::wal::wal_header);
+
+  auto ret = make_lw_shared<wal_read_reply>();
+  auto req = make_lw_shared<wal_read_request>(r);
+  return repeat([ret, this, req]() mutable {
+           if (req->size <= 0) {
+             return make_ready_future<stop_iteration>(stop_iteration::yes);
+           }
+           return this->read_exactly(req->offset, kHeaderSize, req->pc)
+             .then([this, ret, req](auto buf) mutable {
+               auto hdr = get_header(buf);
+               validate_header(hdr, file_size);
+               req->offset += kHeaderSize;
+               req->size -= kHeaderSize;
+               return this->read_exactly(req->offset, hdr.size(), req->pc)
+                 .then([ret, hdr, this, req](auto buf) mutable {
+                   validate_payload(hdr, buf);
+                   req->offset += hdr.size();
+                   req->size -= hdr.size();
+                   wal_read_reply::fragment f(hdr, std::move(buf));
+                   ret->fragments.emplace_back(std::move(f));
+                   if (req->size <= 0) {
+                     return stop_iteration::yes;
+                   }
+                   return stop_iteration::no;
+                 });
+             })
+             .handle_exception([req](std::exception_ptr eptr) {
+               try {
+                 if (eptr) {
+                   std::rethrow_exception(eptr);
+                 }
+               } catch (const std::exception &e) {
+                 LOG_ERROR("Caught exception: {}. Offset:{}, size:{}", e.what(),
+                           req->offset, req->size);
+               }
+               return stop_iteration::yes;
+             });
+         })
+    .then([ret] { return make_ready_future<ret_type>(ret); });
 }
+
 }  // namespace smf

--- a/src/filesystem/wal_file_walker.h
+++ b/src/filesystem/wal_file_walker.h
@@ -25,7 +25,7 @@ struct wal_file_walker {
     return make_ready_future<>();
   }
 
-  future<> close() { return listing.done(); }
+  future<> done() { return listing.done(); }
 
   file                          directory;
   subscription<directory_entry> listing;

--- a/src/filesystem/wal_impl_with_cache.cc
+++ b/src/filesystem/wal_impl_with_cache.cc
@@ -51,7 +51,7 @@ future<> wal_impl_with_cache::open() {
     .then([this, dir] {
       return open_directory(dir).then([this](file f) {
         auto l = make_lw_shared<wal_file_name_mender>(std::move(f));
-        return l->close().finally([l] {});
+        return l->done().finally([l] {});
       });
     })
     .then([this] {

--- a/src/filesystem/wal_pretty_print_utils.cc
+++ b/src/filesystem/wal_pretty_print_utils.cc
@@ -1,0 +1,27 @@
+#include "filesystem/wal_pretty_print_utils.h"
+
+namespace std {
+ostream &operator<<(ostream &o, const ::smf::fbs::wal::wal_header &h) {
+  namespace fl = ::smf::fbs::wal;
+  o << "{'flags':'";
+  auto flags = static_cast<uint32_t>(h.flags());
+  if (flags & fl::wal_entry_flags::wal_entry_flags_partial_fragment) {
+    o << "(partial_fragment)";
+  }
+  if (flags & fl::wal_entry_flags::wal_entry_flags_full_frament) {
+    o << "(full_frament)";
+  }
+  if (flags & fl::wal_entry_flags::wal_entry_flags_zstd) {
+    o << "(zstd)";
+  }
+  o << "', 'size':" << h.size() << ", 'checksum':" << h.checksum() << "}";
+  return o;
+}
+
+ostream &operator<<(ostream &o, const ::smf::wal_read_request &r) {
+  o << "{'offset':" << r.offset << ", 'size':" << r.size
+    << ", 'flags': " << r.flags << " }";
+  return o;
+}
+
+}  // namespace std

--- a/src/filesystem/wal_pretty_print_utils.h
+++ b/src/filesystem/wal_pretty_print_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <iostream>
+#include "filesystem/wal_requests.h"
+#include "flatbuffers/wal_generated.h"
+
+namespace std {
+ostream &operator<<(ostream &o, const ::smf::fbs::wal::wal_header &h);
+ostream &operator<<(ostream &o, const ::smf::wal_read_request &r);
+}  // namespace std

--- a/src/filesystem/wal_reader.h
+++ b/src/filesystem/wal_reader.h
@@ -33,14 +33,14 @@ class wal_reader {
     std::unique_ptr<wal_reader_node> node;
   };
   struct reader_bucket_key {
-    typedef uint64_t type;
+    typedef int64_t type;
     const type &operator()(const reader_bucket &v) const {
       return v.node->starting_epoch;
     }
   };
   using intrusive_key = boost::intrusive::key_of_value<reader_bucket_key>;
   using intrusive_map = boost::intrusive::set<reader_bucket, intrusive_key>;
-  static_assert(std::is_same<intrusive_map::key_type, uint64_t>::value,
+  static_assert(std::is_same<intrusive_map::key_type, int64_t>::value,
                 "bad key for intrusive map");
 
  public:

--- a/src/filesystem/wal_reader_node.h
+++ b/src/filesystem/wal_reader_node.h
@@ -17,8 +17,8 @@ class wal_reader_node {
   wal_reader_node(uint64_t epoch, sstring filename, reader_stats *stats);
   ~wal_reader_node();
 
-  const uint64_t starting_epoch;
-  const sstring  filename;
+  const int64_t starting_epoch;
+  const sstring filename;
 
   /// \brief flushes the file before closing
   future<> close();
@@ -26,8 +26,8 @@ class wal_reader_node {
 
   future<wal_read_reply::maybe> get(wal_read_request r);
 
-  inline uint64_t file_size() { return io_->file_size; }
-  inline uint64_t ending_epoch() const {
+  inline int64_t file_size() { return io_->file_size; }
+  inline int64_t ending_epoch() const {
     return starting_epoch + io_->file_size;
   }
 

--- a/src/filesystem/wal_writer.cc
+++ b/src/filesystem/wal_writer.cc
@@ -62,7 +62,7 @@ future<> wal_writer::open_non_empty_dir(sstring last_file, sstring prefix) {
 future<> wal_writer::do_open() {
   return open_directory(directory).then([this](file f) {
     auto l = make_lw_shared<wal_head_file_max_functor>(std::move(f));
-    return l->close().then([l, this]() {
+    return l->done().then([l, this]() {
       sstring run_prefix = to_sstring(time_now_micros()) + ":";
       if (l->last_file.empty()) {
         return open_empty_dir(run_prefix);

--- a/src/filesystem/wal_writer_node.cc
+++ b/src/filesystem/wal_writer_node.cc
@@ -49,6 +49,8 @@ future<> wal_writer_node::open() {
 // this might not be needed. hehe.
 future<> wal_writer_node::do_append_with_header(fbs::wal::wal_header h,
                                                 wal_write_request    req) {
+  h.mutate_checksum(xxhash_32(req.data.get(), req.data.size()));
+  h.mutate_size(req.data.size());
   current_size_ += kWalHeaderSize;
   return lease_->append((const char *)&h, kWalHeaderSize).then([
     this, req = std::move(req)
@@ -58,19 +60,21 @@ future<> wal_writer_node::do_append_with_header(fbs::wal::wal_header h,
   });
 }
 
+static void add_binary_flags(fbs::wal::wal_header &    o,
+                             fbs::wal::wal_entry_flags f) {
+  auto b = static_cast<uint32_t>(o.flags()) | static_cast<uint32_t>(f);
+  o.mutate_flags(static_cast<fbs::wal::wal_entry_flags>(b));
+}
 
 future<> wal_writer_node::do_append_with_flags(
   wal_write_request req, fbs::wal::wal_entry_flags flags) {
   fbs::wal::wal_header hdr;
-  hdr.mutate_flags(flags);
+  add_binary_flags(hdr, flags);
   auto const write_size = wal_write_request_size(req);
   assert(write_size <= space_left());
-
   if (write_size <= opts_.min_compression_size
       || (req.flags & wal_write_request_flags::wwrf_no_compression)
            == wal_write_request_flags::wwrf_no_compression) {
-    hdr.mutate_size(req.data.size());
-    hdr.mutate_checksum(xxhash_64(req.data.get(), req.data.size()));
     return do_append_with_header(hdr, std::move(req));
   }
 
@@ -86,12 +90,7 @@ future<> wal_writer_node::do_append_with_flags(
   auto zstd_err = ZSTD_isError(zstd_compressed_size);
   if (SMF_LIKELY(zstd_err == 0)) {
     compressed_buf.trim(zstd_compressed_size);
-    flags = (fbs::wal::wal_entry_flags)(
-      (uint32_t)flags
-      | (uint32_t)fbs::wal::wal_entry_flags::wal_entry_flags_zstd);
-    hdr.mutate_flags(flags);
-    hdr.mutate_size(zstd_compressed_size);
-    hdr.mutate_checksum(xxhash_64(compressed_buf.get(), zstd_compressed_size));
+    add_binary_flags(hdr, fbs::wal::wal_entry_flags::wal_entry_flags_zstd);
     wal_write_request compressed_req(req.flags, std::move(compressed_buf),
                                      req.pc);
     return do_append_with_header(hdr, std::move(compressed_req));
@@ -101,13 +100,6 @@ future<> wal_writer_node::do_append_with_flags(
             zstd_err, ZSTD_getErrorName(zstd_err));
 }
 
-future<> wal_writer_node::pad_end_of_file() {
-  // This is important so that when a user cat's together files, they
-  // are also page-cache multiples.
-  temporary_buffer<char> zero(space_left());
-  std::memset(zero.get_write(), 0, zero.size());
-  return lease_->append(zero.get(), zero.size());
-}
 future<uint64_t> wal_writer_node::append(wal_write_request req) {
   const auto offset = opts_.epoch += current_size_;
   return do_append(std::move(req)).then([offset] {
@@ -122,10 +114,8 @@ future<> wal_writer_node::do_append(wal_write_request req) {
       std::move(req), fbs::wal::wal_entry_flags::wal_entry_flags_full_frament);
   }
   if (space_left() < min_entry_size()) {
-    return pad_end_of_file().then([this, req = std::move(req)]() mutable {
-      return rotate_fstream().then([this, req = std::move(req)]() mutable {
-        return do_append(std::move(req));
-      });
+    return rotate_fstream().then([this, req = std::move(req)]() mutable {
+      return do_append(std::move(req));
     });
   }
   // enough space, bigger than min_entry
@@ -147,6 +137,7 @@ future<> wal_writer_node::close() {
 }
 wal_writer_node::~wal_writer_node() {}
 future<> wal_writer_node::rotate_fstream() {
+  LOG_INFO("rotating fstream");
   // Schedule the future<> close().
   // Let the I/O scheduler close it concurrently
   auto ptr = lease_.release();

--- a/src/filesystem/wal_writer_node.h
+++ b/src/filesystem/wal_writer_node.h
@@ -66,7 +66,6 @@ class wal_writer_node {
   future<> do_append(wal_write_request);
   future<> do_append_with_flags(wal_write_request, fbs::wal::wal_entry_flags);
   future<> do_append_with_header(fbs::wal::wal_header, wal_write_request);
-  future<> pad_end_of_file();
 
  private:
   wal_writer_node_opts                   opts_;

--- a/src/flatbuffers/rpc.fbs
+++ b/src/flatbuffers/rpc.fbs
@@ -19,8 +19,7 @@ enum Flags:uint (bit_flags) {
 struct Header {
   size: uint;
   flags: Flags = 0;
-  /// \brief at the moment we use xxhash_64 bit version
-  /// and truncate it with static_cast<uint32_t>(xxhash)
+  /// currently we use xxhash32
   checksum: uint;
 }
 

--- a/src/integration_tests/CMakeLists.txt
+++ b/src/integration_tests/CMakeLists.txt
@@ -28,6 +28,10 @@ add_executable(wal ${IT_ROOT}/wal/main.cc)
 target_link_libraries(wal smf_filesystem smfrpc)
 register_integration_test(wal ${IT_ROOT}/wal)
 
+add_executable(clock_pro ${IT_ROOT}/wal_clock_pro_cache/main.cc)
+target_link_libraries(clock_pro smf_filesystem)
+register_integration_test(clock_pro ${IT_ROOT}/wal_writer)
+
 add_custom_target(integration
   COMMAND ctest --output-on-failure
   DEPENDS ${IT_TESTS})

--- a/src/integration_tests/wal/main.cc
+++ b/src/integration_tests/wal/main.cc
@@ -61,8 +61,10 @@ int main(int args, char **argv, char **env) {
                 return x.append(gen_payload(kPayload)).then([&x](uint64_t i) {
                   auto &p = smf::priority_manager::thread_local_instance()
                               .default_priority();
-                  smf::wal_read_request rq{i, (uint64_t)std::strlen(kPayload),
-                                           uint32_t(0), p};
+                  smf::wal_read_request rq{
+                    static_cast<int64_t>(i),
+                    static_cast<int64_t>(std::strlen(kPayload)), uint32_t(0),
+                    p};
                   return x.get(std::move(rq)).then([i](auto read_result) {
                     assert(read_result);
                     auto size = read_result->fragments.front().data.size();

--- a/src/integration_tests/wal_clock_pro_cache/main.cc
+++ b/src/integration_tests/wal_clock_pro_cache/main.cc
@@ -1,0 +1,109 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+// seastar
+#include <core/app-template.hh>
+#include <core/distributed.hh>
+// smf
+#include "filesystem/wal_pretty_print_utils.h"
+#include "filesystem/wal_reader.h"
+#include "filesystem/wal_requests.h"
+#include "filesystem/wal_writer.h"
+#include "platform/log.h"
+#include "seastar_io/priority_manager.h"
+
+smf::wal_write_request gen_payload() {
+  static const sstring kPayload =
+    "How do I love thee? Let me count the ways."
+    "I love thee to the depth and breadth and height"
+    "My soul can reach, when feeling out of sight"
+    "For the ends of being and ideal grace."
+    "I love thee to the level of every day's"
+    "Most quiet need, by sun and candle-light."
+    "I love thee freely, as men strive for right."
+    "I love thee purely, as they turn from praise."
+    "I love thee with the passion put to use"
+    "In my old griefs, and with my childhood's faith."
+    "I love thee with a love I seemed to lose"
+    "With my lost saints. I love thee with the breath,"
+    "Smiles, tears, of all my life; and, if God choose,"
+    "I shall but love thee better after death."
+    "How do I love thee? Let me count the ways."
+    "I love thee to the depth and breadth and height"
+    "My soul can reach, when feeling out of sight"
+    "For the ends of being and ideal grace."
+    "I love thee to the level of every day's"
+    "Most quiet need, by sun and candle-light."
+    "I love thee freely, as men strive for right."
+    "I love thee purely, as they turn from praise."
+    "I love thee with the passion put to use"
+    "In my old griefs, and with my childhood's faith."
+    "I love thee with a love I seemed to lose"
+    "With my lost saints. I love thee with the breath,"
+    "Smiles, tears, of all my life; and, if God choose,"
+    "I shall but love thee better after death.";
+  temporary_buffer<char> buf(kPayload.size());
+  std::copy(kPayload.begin(), kPayload.end(), buf.get_write());
+  return smf::wal_write_request(
+    0, std::move(buf),
+    smf::priority_manager::thread_local_instance().default_priority());
+}
+future<> write(uint32_t max) {
+  auto wstats = make_lw_shared<smf::writer_stats>();
+  auto writer = make_lw_shared<smf::wal_writer>(".", wstats.get());
+
+  return writer->open()
+    .then([wstats, writer, max] {
+      return do_for_each(
+        boost::counting_iterator<uint32_t>(0),
+        boost::counting_iterator<uint32_t>(max), [wstats, writer](auto i) {
+          return writer->append(gen_payload()).then([writer](auto epoch) {
+            return make_ready_future<>();
+          });
+        });
+    })
+    .then([writer, wstats] {
+      return writer->close().finally([writer, wstats] {});
+    });
+}
+
+smf::wal_read_request gen_read_request() {
+  static const ::io_priority_class &pc =
+    smf::priority_manager::thread_local_instance().default_priority();
+  return smf::wal_read_request(uint64_t(0), uint64_t(1000000), uint32_t(0), pc);
+}
+
+
+future<> read(uint32_t expected_heder_count) {
+  auto rstats = make_lw_shared<smf::reader_stats>();
+  auto reader = make_lw_shared<smf::wal_reader>(".", rstats.get());
+  return reader->open()
+    .then([reader, rstats, expected_heder_count]() mutable {
+      auto r = gen_read_request();
+      DLOG_INFO("Read request: {}", r);
+      return reader->get(r).then([reader, expected_heder_count](auto maybe) {
+        DLOG_THROW_IF(!maybe, "eeeee... supposed to have some");
+        DLOG_INFO("fragments: {}", maybe->fragments.size());
+        DLOG_THROW_IF(expected_heder_count != maybe->fragments.size(),
+                      "fragment size does not match expected fragment count");
+        DLOG_INFO("Size of read request: {}", maybe->size());
+        return make_ready_future<>();
+      });
+    })
+    .then([reader, rstats] {
+      return reader->close().finally([reader, rstats] {});
+    });
+}
+
+static const uint32_t kNumberOfAppends = 1000;
+int main(int args, char **argv, char **env) {
+  app_template app;
+  try {
+    return app.run(args, argv, [&]() mutable -> future<int> {
+      return write(kNumberOfAppends)
+        .then([] { return read(kNumberOfAppends); })
+        .then([] { return make_ready_future<int>(0); });
+    });
+  } catch (const std::exception &e) {
+    std::cerr << "Fatal exception: " << e.what() << std::endl;
+  }
+}

--- a/src/integration_tests/wal_clock_pro_cache/test.json
+++ b/src/integration_tests/wal_clock_pro_cache/test.json
@@ -1,0 +1,4 @@
+{
+  "args": ["-c 1", "-m 1G"],
+  "tmp_home": true
+}


### PR DESCRIPTION
* Main bug: need to find the offset into each file regardless
  of wether the file is a completely padded mem_aligned or not

  In addition, we must take into account the offset between pages

* Fixed wal_writer not to pad the file
  we just have to deal w/ the fact that the server
  will crash and need to fix half padded files

* Add read_exactly<>() patterns inspired by the
  input_stream_reader<> class.

* use aligned_buffers w/ pmem_aligned*

* tests: add tests for wal_reading using clock-pro

* change types from temporary_buffer<> to
  unique_ptr<char_type[], free_deleter> to use alligned
  buffers

* Add checksums for header and payload

* Add checks to make sure we don't read more than 1 page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/senior7515/smf/74)
<!-- Reviewable:end -->
