### PR TITLE
smf_gen: Use object API in generated code

### DIFF
--- a/src/chain_replication/chain_replication_service.cc
+++ b/src/chain_replication/chain_replication_service.cc
@@ -11,12 +11,13 @@
 
 namespace smf {
 namespace chains {
-future<smf::rpc_envelope> chain_replication_service::put(
+future<smf::rpc_typed_envelope<tx_put_reply>> chain_replication_service::put(
   smf::rpc_recv_typed_context<tx_put_request> &&record) {
   if (!record) {
-    smf::rpc_envelope e;
-    e.set_status(501);  // Not implemented
-    return make_ready_future<smf::rpc_envelope>(std::move(e));
+    smf::rpc_typed_envelope<tx_put_reply> data;
+    data.envelope.set_status(400);
+    return make_ready_future<smf::rpc_typed_envelope<tx_put_reply>>(
+      std::move(data));
   }
   auto core_to_handle = put_to_lcore(record.get());
   return smp::submit_to(
@@ -36,24 +37,27 @@ future<smf::rpc_envelope> chain_replication_service::put(
              return wal_->local().append(std::move(r));
            })
     .then([](uint64_t last_index) {
-      smf::rpc_envelope e;
-      e.set_status(200);
-      return make_ready_future<smf::rpc_envelope>(std::move(e));
+      smf::rpc_typed_envelope<tx_put_reply> data;
+      data.envelope.set_status(200);
+      return make_ready_future<smf::rpc_typed_envelope<tx_put_reply>>(
+        std::move(data));
     })
     .handle_exception([](std::exception_ptr eptr) {
       LOG_ERROR("Error saving smf::chains::sput()");
-      smf::rpc_envelope e;
-      e.set_status(500);
-      return make_ready_future<smf::rpc_envelope>(std::move(e));
+      smf::rpc_typed_envelope<tx_put_reply> data;
+      data.envelope.set_status(501);
+      return make_ready_future<smf::rpc_typed_envelope<tx_put_reply>>(
+        std::move(data));
     });
 }
 
 
-future<smf::rpc_envelope> chain_replication_service::get(
+future<smf::rpc_typed_envelope<tx_get_reply>> chain_replication_service::get(
   smf::rpc_recv_typed_context<tx_get_request> &&record) {
-  smf::rpc_envelope e;
-  e.set_status(501);  // Not implemented
-  return make_ready_future<smf::rpc_envelope>(std::move(e));
+  smf::rpc_typed_envelope<tx_get_reply> data;
+  data.envelope.set_status(501);
+  return make_ready_future<smf::rpc_typed_envelope<tx_get_reply>>(
+    std::move(data));
 }
 }  // end namespace chains
 }  // end namespace smf

--- a/src/chain_replication/chain_replication_service.h
+++ b/src/chain_replication/chain_replication_service.h
@@ -11,9 +11,12 @@ class chain_replication_service : public chains::chain_replication {
  public:
   explicit chain_replication_service(distributed<smf::write_ahead_log> *w)
     : wal_(w) {}
-  using env_t = future<smf::rpc_envelope>;
-  env_t put(smf::rpc_recv_typed_context<tx_put_request> &&) final;
-  env_t get(smf::rpc_recv_typed_context<tx_get_request> &&) final;
+
+  virtual future<smf::rpc_typed_envelope<tx_put_reply>>
+  put(smf::rpc_recv_typed_context<tx_put_request> &&) final;
+
+  virtual future<smf::rpc_typed_envelope<tx_get_reply>>
+  get(smf::rpc_recv_typed_context<tx_get_request> &&) final;
 
  private:
   distributed<smf::write_ahead_log> *wal_;

--- a/src/integration_tests/rpc/main.cc
+++ b/src/integration_tests/rpc/main.cc
@@ -72,11 +72,12 @@ struct generator {
 
 
 class storage_service : public smf_gen::demo::SmfStorage {
-  future<smf::rpc_envelope> Get(
+  virtual future<smf::rpc_typed_envelope<smf_gen::demo::Response>> Get(
     smf::rpc_recv_typed_context<smf_gen::demo::Request> &&rec) final {
-    smf::rpc_envelope e;
-    e.set_status(200);
-    return make_ready_future<smf::rpc_envelope>(std::move(e));
+    smf::rpc_typed_envelope<smf_gen::demo::Response> data;
+    data.envelope.set_status(200);
+    return make_ready_future<smf::rpc_typed_envelope<smf_gen::demo::Response>>(
+      std::move(data));
   }
 };
 

--- a/src/rpc/rpc_letter_concepts.h
+++ b/src/rpc/rpc_letter_concepts.h
@@ -1,0 +1,19 @@
+// Copyright 2017 Alexander Gallego
+//
+#pragma once
+
+#include <flatbuffers/flatbuffers.h>
+
+namespace smf {
+// clang does not yet know how to format concepts
+// so putting all concepts on a different section
+// clang-format off
+
+    template <typename T>
+    concept bool FlatBuffersNativeTable = requires(T a) {
+      { std::is_base_of<flatbuffers::NativeTable, typename T::NativeTableType>::value == true };
+      { std::is_base_of<flatbuffers::Table, T>::value == true };
+    }; // NOLINT
+
+// clang-format on
+} // namespace smf

--- a/src/rpc/rpc_typed_envelope.h
+++ b/src/rpc/rpc_typed_envelope.h
@@ -1,15 +1,41 @@
 // Copyright (c) 2017 Alexander Gallego. All rights reserved.
 //
 #pragma once
-// smf
-#include "platform/macros.h"
 
+#include "rpc/rpc_letter_concepts.h"
+
+#include "platform/macros.h"
 #include "rpc/rpc_envelope.h"
 
 namespace smf {
-template <typename T> rpc_typed_envelope {
-  using typename type = T;
-  rpc_envelope envelope;
+template <typename RootType>
+requires FlatBuffersNativeTable<RootType> struct rpc_typed_envelope {
+  using type = typename RootType::NativeTableType;
+
+  rpc_envelope          envelope;
+  std::unique_ptr<type> data;
+
+
+  rpc_typed_envelope() : data(std::make_unique<type>()) {}
+  ~rpc_typed_envelope() {}
+  rpc_typed_envelope(std::unique_ptr<type> &&ptr) noexcept
+    : data(std::move(ptr)) {}
+  rpc_typed_envelope &operator=(rpc_typed_envelope<RootType> &&te) noexcept {
+    envelope = std::move(te.envelope);
+    data     = std::move(te.data);
+    return *this;
+  }
+  rpc_typed_envelope(rpc_typed_envelope<RootType> &&te) noexcept {
+    *this = std::move(te);
+  }
+  /// \brief this copies this->data into this->envelope
+  /// and retuns a *moved* copy of the envelope. That is
+  /// the envelope will be invalid after this method call
+  rpc_envelope &&serialize_data() {
+    rpc_letter::serialize_type_into_letter<RootType>(*(data.get()),
+                                                     envelope.letter);
+    return std::move(envelope);
+  }
   /// \brief copy ctor deleted
   SMF_DISALLOW_COPY_AND_ASSIGN(rpc_typed_envelope);
 };


### PR DESCRIPTION
1) Use the object API from flatbuffers now that we have a generic way of
typing the messages.

Introduce the `rpc_typed_envelope` which allows users to use a
struct-like or POD data api for their return types and lets the framework
manage the types & memory for them.
This feels more natural and is on par w/ gRPC and ApacheThrift api's.

2) rpc: add rpc_letter concepts for type conversions

rpc_letter MUST take in a root param type of a flatbuffers::Table
but will pass in as arguments flatbuffers::NativeTable via a

```

T::Pack(Builder, typename T::NativeTable) function call

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/senior7515/smf/108)
<!-- Reviewable:end -->
