### PR TITLE
compression: add lz4 size before writing the buffer

### DIFF
--- a/src/integration_tests/rpc_recv_timeout/main.cc
+++ b/src/integration_tests/rpc_recv_timeout/main.cc
@@ -22,11 +22,7 @@
 class storage_service : public smf_gen::demo::SmfStorage {
   virtual seastar::future<smf::rpc_typed_envelope<smf_gen::demo::Response>> Get(
     smf::rpc_recv_typed_context<smf_gen::demo::Request> &&rec) final {
-    smf::rpc_typed_envelope<smf_gen::demo::Response> data;
-    data.envelope.set_status(200);
-    return seastar::
-      make_ready_future<smf::rpc_typed_envelope<smf_gen::demo::Response>>(
-        std::move(data));
+    LOG_THROW("SHOULD NOT REACH THIS W/ A TIMEOUT");
   }
 };
 
@@ -85,18 +81,7 @@ int main(int args, char **argv, char **env) {
             return conn->ostream.write(std::move(header_buf))
               .then([conn] { return conn->ostream.flush(); })
               .then([conn] {
-                // NOTE: This test will block forever until there is an
-                // exception with a timeout!
-
-                // block reading the input
-                return smf::rpc_recv_context::parse(conn.get())
-                  .then([conn](auto x) {
-                    if (x) {
-                      throw std::runtime_error(
-                        "THE SERVER DID NOT CLOSE the timeout connection");
-                    }
-                    return seastar::make_ready_future<>();
-                  });
+                  return seastar::sleep(std::chrono::milliseconds(10));
               })
               .finally([conn] {});
           });

--- a/src/platform/log.h
+++ b/src/platform/log.h
@@ -51,11 +51,12 @@ T *throw_if_null(const char *file, int line, const char *names, T *t) {
 #define LOG_TRACE(format, args...)                                            \
   smf::internal_logger::get().trace("{}:{}] " format, __FILENAME__, __LINE__, \
                                     ##args)
-#define LOG_THROW(format, args...)                                           \
-  do {                                                                       \
-    auto s = fmt::sprintf("{}:{}] " format, __FILENAME__, __LINE__, ##args); \
-    smf::internal_logger::get().error(s.c_str());                            \
-    throw std::runtime_error(s.c_str());                                     \
+#define LOG_THROW(format, args...)                             \
+  do {                                                         \
+    fmt::MemoryWriter w;                                       \
+    w.write("{}:{}] " format, __FILENAME__, __LINE__, ##args); \
+    smf::internal_logger::get().error(w.data());               \
+    throw std::runtime_error(w.data());                        \
   } while (0)
 
 #define THROW_IFNULL(val)                            \
@@ -96,14 +97,15 @@ T *throw_if_null(const char *file, int line, const char *names, T *t) {
                                         __FILENAME__, __LINE__, ##args);   \
     }                                                                      \
   } while (0)
-#define LOG_THROW_IF(condition, format, args...)                             \
-  do {                                                                       \
-    if (SMF_UNLIKELY(condition)) {                                           \
-      auto s = fmt::sprintf("{}:{}] (" #condition ") " format, __FILENAME__, \
-                            __LINE__, ##args);                               \
-      smf::internal_logger::get().error(s.c_str());                          \
-      throw std::runtime_error(s.c_str());                                   \
-    }                                                                        \
+#define LOG_THROW_IF(condition, format, args...)                         \
+  do {                                                                   \
+    if (SMF_UNLIKELY(condition)) {                                       \
+      fmt::MemoryWriter w;                                               \
+      w.write("{}:{}] (" #condition ") " format, __FILENAME__, __LINE__, \
+              ##args);                                                   \
+      smf::internal_logger::get().error(w.data());                       \
+      throw std::runtime_error(w.data());                                \
+    }                                                                    \
   } while (0)
 
 
@@ -162,14 +164,15 @@ T *throw_if_null(const char *file, int line, const char *names, T *t) {
                                         __FILENAME__, __LINE__, ##args);   \
     }                                                                      \
   } while (0)
-#define DLOG_THROW_IF(condition, format, args...)                            \
-  do {                                                                       \
-    if (SMF_UNLIKELY(condition)) {                                           \
-      auto s = fmt::sprintf("{}:{}] (" #condition ") " format, __FILENAME__, \
-                            __LINE__, ##args);                               \
-      smf::internal_logger::get().error(s.c_str());                          \
-      throw std::runtime_error(s.c_str());                                   \
-    }                                                                        \
+#define DLOG_THROW_IF(condition, format, args...)                        \
+  do {                                                                   \
+    if (SMF_UNLIKELY(condition)) {                                       \
+      fmt::MemoryWriter w;                                               \
+      w.write("{}:{}] (" #condition ") " format, __FILENAME__, __LINE__, \
+              ##args);                                                   \
+      smf::internal_logger::get().error(w.data());                       \
+      throw std::runtime_error(w.data());                                \
+    }                                                                    \
   } while (0)
 
 #else

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -9,6 +9,7 @@ set(RPC_LIB_SOURCES
   ${PROJECT_SOURCE_DIR}/src/rpc/rpc_connection_limits.cc
   ${PROJECT_SOURCE_DIR}/src/rpc/rpc_letter.cc
   ${PROJECT_SOURCE_DIR}/src/rpc/filters/zstd_filter.cc
+  ${PROJECT_SOURCE_DIR}/src/rpc/filters/lz4_filter.cc
   )
 add_library(smf_rpc STATIC ${RPC_LIB_SOURCES})
 target_link_libraries(smf_rpc smf_utils smf_tracing)

--- a/src/rpc/filters/lz4_filter.cc
+++ b/src/rpc/filters/lz4_filter.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#include "rpc/filters/lz4_filter.h"
+
+#include <utility>
+
+#include "rpc/rpc_header_utils.h"
+#include "rpc/rpc_recv_context.h"
+#include "utils/compression.h"
+
+namespace smf {
+
+static thread_local auto compressor =
+  codec::make_unique(codec_type::lz4, compression_level::fastest);
+
+seastar::future<rpc_envelope> lz4_compression_filter::operator()(
+  rpc_envelope &&e) {
+  if (e.letter.header.compression()
+      != rpc::compression_flags::compression_flags_none) {
+    return seastar::make_ready_future<rpc_envelope>(std::move(e));
+  }
+  if (e.letter.body.size() <= min_compression_size) {
+    return seastar::make_ready_future<rpc_envelope>(std::move(e));
+  }
+
+  auto buf      = compressor->compress(e.letter.body);
+  e.letter.body = std::move(buf);
+  e.letter.header.mutate_compression(
+    rpc::compression_flags::compression_flags_lz4);
+  checksum_rpc(e.letter.header, e.letter.body.get(), e.letter.body.size());
+
+  return seastar::make_ready_future<rpc_envelope>(std::move(e));
+}
+
+
+seastar::future<rpc_recv_context> lz4_decompression_filter::operator()(
+  rpc_recv_context &&ctx) {
+  if (ctx.header.compression()
+      == rpc::compression_flags::compression_flags_lz4) {
+    auto buf = compressor->uncompress(ctx.payload);
+    ctx.payload = std::move(buf);
+    ctx.header.mutate_compression(
+      rpc::compression_flags::compression_flags_none);
+    checksum_rpc(ctx.header, ctx.payload.get(), ctx.payload.size());
+  }
+  return seastar::make_ready_future<rpc_recv_context>(std::move(ctx));
+}
+
+
+}  // namespace smf

--- a/src/rpc/filters/lz4_filter.h
+++ b/src/rpc/filters/lz4_filter.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#pragma once
+
+#include "rpc/rpc_envelope.h"
+#include "rpc/rpc_filter.h"
+#include "rpc/rpc_recv_context.h"
+
+namespace smf {
+
+struct lz4_compression_filter : rpc_filter<rpc_envelope> {
+  explicit lz4_compression_filter(uint32_t _min_compression_size)
+    : min_compression_size(_min_compression_size) {}
+
+  seastar::future<rpc_envelope> operator()(rpc_envelope &&e);
+
+  const uint32_t min_compression_size;
+};
+
+struct lz4_decompression_filter : rpc_filter<rpc_envelope> {
+  seastar::future<rpc_recv_context> operator()(rpc_recv_context &&ctx);
+};
+
+} //namespace smf

--- a/src/rpc/load_gen/load_channel.h
+++ b/src/rpc/load_gen/load_channel.h
@@ -6,6 +6,7 @@
 
 #include "platform/log.h"
 #include "platform/macros.h"
+#include "rpc/filters/lz4_filter.h"
 #include "rpc/filters/zstd_filter.h"
 #include "rpc/load_gen/generator_duration.h"
 #include "rpc/rpc_client.h"
@@ -33,7 +34,11 @@ template <typename ClientService> struct load_channel {
     client->enable_histogram_metrics();
     if (compression == smf::rpc::compression_flags::compression_flags_zstd) {
       client->incoming_filters().push_back(smf::zstd_decompression_filter());
-      client->outgoing_filters().push_back(smf::zstd_compression_filter(1000));
+      client->outgoing_filters().push_back(smf::zstd_compression_filter(1024));
+    } else if (compression
+               == smf::rpc::compression_flags::compression_flags_lz4) {
+      client->incoming_filters().push_back(smf::lz4_decompression_filter());
+      client->outgoing_filters().push_back(smf::lz4_compression_filter(1024));
     }
   }
 

--- a/src/smfb/client/low_level_client.cc
+++ b/src/smfb/client/low_level_client.cc
@@ -136,7 +136,7 @@ int main(int argc, char **argv, char **env) {
         cfg["ip"].as<std::string>().c_str(), cfg["port"].as<uint16_t>(),
         cfg["req-num"].as<uint32_t>(), cfg["concurrency"].as<uint32_t>(),
         static_cast<uint64_t>(0.9 * seastar::memory::stats().total_memory()),
-        smf::rpc::compression_flags::compression_flags_none, cfg);
+        smf::rpc::compression_flags::compression_flags_lz4, cfg);
 
       LOG_INFO("Preparing load of test: {}", largs);
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -35,3 +35,10 @@ smf_test(
   SOURCE_DIRECTORY ${TEST_ROOT}/clock_pro
   LIBRARIES gtest smf_filesystem
   )
+smf_test(
+  UNIT_TEST
+  BINARY_NAME compressors
+  SOURCES ${TEST_ROOT}/compressor/main.cc
+  SOURCE_DIRECTORY ${TEST_ROOT}/compressor
+  LIBRARIES gtest smf_utils
+  )

--- a/src/test/compressor/main.cc
+++ b/src/test/compressor/main.cc
@@ -1,0 +1,60 @@
+// Copyright (c) 2016 Alexander Gallego. All rights reserved.
+//
+#include <gtest/gtest.h>
+#include <memory>
+
+#include <core/sstring.hh>
+#include <core/byteorder.hh>
+
+#include "utils/compression.h"
+
+using namespace smf;
+static const char *kPoem = "How do I love thee? Let me count the ways."
+                           "I love thee to the depth and breadth and height"
+                           "My soul can reach, when feeling out of sight"
+                           "For the ends of being and ideal grace."
+                           "I love thee to the level of every day's"
+                           "Most quiet need, by sun and candle-light."
+                           "I love thee freely, as men strive for right."
+                           "I love thee purely, as they turn from praise."
+                           "I love thee with the passion put to use"
+                           "In my old griefs, and with my childhood's faith."
+                           "I love thee with a love I seemed to lose"
+                           "With my lost saints. I love thee with the breath,"
+                           "Smiles, tears, of all my life; and, if God choose,"
+                           "I shall but love thee better after death."
+                           "How do I love thee? Let me count the ways."
+                           "I love thee to the depth and breadth and height"
+                           "My soul can reach, when feeling out of sight"
+                           "For the ends of being and ideal grace."
+                           "I love thee to the level of every day's"
+                           "Most quiet need, by sun and candle-light."
+                           "I love thee freely, as men strive for right."
+                           "I love thee purely, as they turn from praise."
+                           "I love thee with the passion put to use"
+                           "In my old griefs, and with my childhood's faith."
+                           "I love thee with a love I seemed to lose"
+                           "With my lost saints. I love thee with the breath,"
+                           "Smiles, tears, of all my life; and, if God choose,"
+                           "I shall but love thee better after death.";
+
+TEST(lz4, compresion_decompression) {
+  auto compressor =
+    codec::make_unique(codec_type::lz4, compression_level::fastest);
+  auto c_payload = compressor->compress(kPoem, strlen(kPoem));
+  auto d_payload = compressor->uncompress(c_payload);
+  ASSERT_TRUE(std::memcmp(d_payload.get(), kPoem, strlen(kPoem)) == 0);
+}
+TEST(zstd, compresion_decompression) {
+  auto compressor =
+    codec::make_unique(codec_type::zstd, compression_level::fastest);
+  auto c_payload = compressor->compress(kPoem, strlen(kPoem));
+  auto d_payload = compressor->uncompress(c_payload);
+  ASSERT_TRUE(std::memcmp(d_payload.get(), kPoem, strlen(kPoem)) == 0);
+}
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
currently lz4 either needs a very long and expensive frame with
header and footer of 20-something bytes. Or it uses the block
api wich has no frame or encoding.

The current design is to embed an int as little endian
on the first 4 bytes of the encoded buffer, so we can decode it later.