### PR TITLE
rpc: smf_gen add custom output path for generator

### DIFF
--- a/src/rpc/smf_gen/CMakeLists.txt
+++ b/src/rpc/smf_gen/CMakeLists.txt
@@ -5,6 +5,8 @@ set(SMF_GEN_SOURCES
   )
 set(SMF_GEN_LIBS
   flatbuffers.a
+  boost_system
+  boost_filesystem
   gflags
   glog
   pthread

--- a/src/rpc/smf_gen/idl.cc
+++ b/src/rpc/smf_gen/idl.cc
@@ -11,9 +11,7 @@
 DEFINE_bool(print_smf_gen_to_stderr,
             false,
             "prints to stderr the outputs of the generated header");
-DEFINE_string(output_path,
-              "",
-              "prints to stderr the outputs of the generated header");
+DEFINE_string(output_path, "", "output path of the generated files");
 
 
 namespace smf_gen {

--- a/src/rpc/smf_gen/idl.cc
+++ b/src/rpc/smf_gen/idl.cc
@@ -2,6 +2,7 @@
 //
 #include <iostream>
 
+#include <boost/filesystem.hpp>
 #include <glog/logging.h>
 
 #include "rpc/smf_gen/cpp_generator.h"
@@ -10,16 +11,14 @@
 DEFINE_bool(print_smf_gen_to_stderr,
             false,
             "prints to stderr the outputs of the generated header");
+DEFINE_string(output_path,
+              "",
+              "prints to stderr the outputs of the generated header");
+
 
 namespace smf_gen {
-bool generate(const flatbuffers::Parser &parser, const std::string &file_name) {
-  int nservices = 0;
-  for (auto it = parser.services_.vec.begin(); it != parser.services_.vec.end();
-       ++it) {
-    if (!(*it)->generated) nservices++;
-  }
-  if (!nservices) return true;
 
+bool generate(const flatbuffers::Parser &parser, std::string file_name) {
   smf_file fbfile(parser, file_name);
 
   std::string header_code =
@@ -27,12 +26,24 @@ bool generate(const flatbuffers::Parser &parser, const std::string &file_name) {
     + get_header_services(&fbfile) + get_header_epilogue(&fbfile);
 
 
-  if (FLAGS_print_smf_gen_to_stderr) {
-    std::cerr << "Finished generating code: \n" << header_code;
+  if (FLAGS_print_smf_gen_to_stderr) { std::cerr << header_code << std::endl; }
+  if (!FLAGS_output_path.empty()) {
+    FLAGS_output_path =
+      boost::filesystem::canonical(FLAGS_output_path.c_str()).string();
+    if (!flatbuffers::DirExists(FLAGS_output_path.c_str())) {
+      LOG(ERROR) << "--output_path specified, but directory: "
+                 << FLAGS_output_path << " does not exist;";
+      return false;
+    }
+    boost::filesystem::path p(file_name);
+    file_name = p.filename().string();
   }
+  const std::string fname = FLAGS_output_path.empty() ?
+                              file_name + ".smf.fb.h" :
+                              FLAGS_output_path + "/" + file_name + ".smf.fb.h";
+  LOG(INFO) << fname;
 
-  return flatbuffers::SaveFile((file_name + ".smf.fb.h").c_str(), header_code,
-                               false);
+  return flatbuffers::SaveFile(fname.c_str(), header_code, false);
 }
 
 }  // namespace smf_gen

--- a/src/rpc/smf_gen/idl.h
+++ b/src/rpc/smf_gen/idl.h
@@ -4,5 +4,5 @@
 #include <flatbuffers/flatbuffers.h>
 #include <flatbuffers/idl.h>
 namespace smf_gen {
-bool generate(const flatbuffers::Parser &parser, const std::string &file_name);
+bool generate(const flatbuffers::Parser &parser, std::string file_name);
 }  // namespace smf_gen

--- a/src/rpc/smf_gen/main.cc
+++ b/src/rpc/smf_gen/main.cc
@@ -1,13 +1,16 @@
 // Copyright (c) 2016 Alexander Gallego. All rights reserved.
 //
+#include <iostream>
+#include <vector>
+
+#include <boost/filesystem.hpp>
 #include <flatbuffers/flatbuffers.h>
 #include <flatbuffers/util.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <iostream>
-#include <vector>
 
 #include "rpc/smf_gen/idl.h"
+
 DEFINE_string(filename, "", "filename to parse");
 DEFINE_string(include_dirs, "", "extra include directories: not supported yet");
 
@@ -17,10 +20,9 @@ int main(int argc, char **argv, char **env) {
   google::InstallFailureSignalHandler();
   google::InitGoogleLogging(argv[0]);
 
-  if (FLAGS_filename.empty()) {
-    LOG(ERROR) << "No filename to parse";
-    exit(1);
-  }
+  LOG_IF(FATAL, FLAGS_filename.empty()) << "No filename to parse";
+  LOG_IF(FATAL, !boost::filesystem::exists(FLAGS_filename))
+    << "File does not exists";
 
   VLOG(1) << "Parsing file: " << FLAGS_filename
           << ", Include dirs: " << FLAGS_include_dirs;
@@ -46,6 +48,9 @@ int main(int argc, char **argv, char **env) {
 
   VLOG(1) << "File `" << FLAGS_filename << "` parsed. Generating";
 
-  smf_gen::generate(parser, flatbuffers::StripExtension(FLAGS_filename));
+  LOG_IF(
+    FATAL,
+    !smf_gen::generate(parser, flatbuffers::StripExtension(FLAGS_filename)))
+    << "Could not generate file";
   parser.MarkGenerated();
 }


### PR DESCRIPTION
User's might want to generate the code outside of the
same directory as the .fbs file