### PR TITLE
Feature/perf

### DIFF
--- a/CMake/base_flags.cmake
+++ b/CMake/base_flags.cmake
@@ -46,5 +46,6 @@ else()
   set(BASE_FLAGS
     ${BASE_FLAGS}
     "-O2"
+    "-ggdb"
     )
 endif()

--- a/docs/_posts/2018-02-08-perf.markdown
+++ b/docs/_posts/2018-02-08-perf.markdown
@@ -1,0 +1,6 @@
+# [ FlameGraph ]( https://github.com/brendangregg/FlameGraph )
+# perf record -F 99 -a -g -- sleep 60
+# perf script | stackcollapse-perf.pl > out.perf-folded
+# ./flamegraph.pl out.perf-folded > perf-kernel.svg
+
+# perf record -e sdt_smf:*

--- a/src/filesystem/wal_partition_manager.h
+++ b/src/filesystem/wal_partition_manager.h
@@ -47,19 +47,13 @@ class wal_partition_manager {
   const uint32_t         partition;
   const seastar::sstring work_dir;
 
-  bool
-  is_open() const {
-    return is_ready_open_;
-  }
-
  private:
   seastar::future<> do_open();
 
  private:
-  bool                                    is_ready_open_ = false;
-  std::unique_ptr<wal_writer>             writer_        = nullptr;
-  std::unique_ptr<wal_reader>             reader_        = nullptr;
-  std::unique_ptr<wal_write_behind_cache> cache_         = nullptr;
+  wal_writer             writer_;
+  wal_reader             reader_;
+  wal_write_behind_cache cache_;
 };
 
 }  // namespace smf

--- a/src/filesystem/wal_ptid.h
+++ b/src/filesystem/wal_ptid.h
@@ -1,0 +1,66 @@
+// Copyright 2018 Alexander Gallego
+//
+
+#pragma once
+
+#include <core/sstring.hh>
+
+#include "hashing/hashing_utils.h"
+
+namespace smf {
+/// \brief compute partition-topic-index id
+inline uint64_t
+wal_ptid_gen_id(const seastar::sstring &topic, const uint32_t &partition) {
+  incremental_xxhash64 inc;
+  inc.update(topic.data(), topic.size());
+  inc.update((char *)&partition, sizeof(partition));
+  return inc.digest();
+}
+
+class wal_ptid {
+ public:
+  wal_ptid(const seastar::sstring &topic, const uint32_t &partition)
+    : id_(wal_ptid_gen_id(topic, partition)) {}
+  ~wal_ptid() = default;
+  wal_ptid(wal_ptid &&o) noexcept : id_(o.id_) {}
+  void
+  operator=(wal_ptid &&o) noexcept {
+    id_ = o.id_;
+  }
+
+  inline uint64_t
+  id() const {
+    return id_;
+  }
+
+ private:
+  friend void swap(wal_ptid &x, wal_ptid &y);
+  uint64_t    id_;
+};
+
+
+/// \brief, helper method for maps/etc
+inline void
+swap(wal_ptid &x, wal_ptid &y) {
+  std::swap(x.id_, y.id_);
+}
+inline bool
+operator<(const wal_ptid &lhs, const wal_ptid &rhs) {
+  return lhs.id() < rhs.id();
+}
+inline bool
+operator==(const wal_ptid &lhs, const wal_ptid &rhs) {
+  return lhs.id() == rhs.id();
+}
+}  // namespace smf
+
+namespace std {
+template <>
+struct hash<smf::wal_ptid> {
+  size_t
+  operator()(const smf::wal_ptid &x) const {
+    return hash<uint64_t>()(x.id());
+  }
+};
+
+}  // namespace std

--- a/src/filesystem/wal_requests.cc
+++ b/src/filesystem/wal_requests.cc
@@ -9,7 +9,7 @@
 namespace smf {
 
 bool
-wal_read_request::validate(const wal_read_request &r) {
+wal_read_request::valid(const wal_read_request &r) {
   try {
     // traversing the fbs might throw
     (void)r.req->partition();
@@ -111,7 +111,9 @@ wal_write_request::wal_write_request(const smf::wal::tx_put_request *    ptr,
   : priority_wrapper(ptr, p)
   , assigned_core(_assigned_core)
   , runner_core(_runner_core)
-  , partition_view(partitions) {}
+  , partition_view(partitions) {
+  DLOG_THROW_IF(partition_view.empty(), "Partition view is empty");
+}
 
 wal_write_request::write_request_iterator
 wal_write_request::begin() {
@@ -124,7 +126,8 @@ wal_write_request::end() {
                                 req->data()->end());
 }
 bool
-wal_write_request::validate(const wal_write_request &r) {
+wal_write_request::valid(const wal_write_request &r) {
+  DLOG_INFO_IF(r.partition_view.empty(), "Partition view is empty!");
   try {
     // traversing the request object might throw
     (void)r.req->topic();

--- a/src/filesystem/wal_requests.h
+++ b/src/filesystem/wal_requests.h
@@ -55,7 +55,7 @@ struct wal_read_request : details::priority_wrapper<smf::wal::tx_get_request> {
     : priority_wrapper(ptr, p) {}
 
 
-  static bool validate(const wal_read_request &r);
+  static bool valid(const wal_read_request &r);
 };
 
 class wal_read_reply {
@@ -143,9 +143,10 @@ struct wal_write_request : details::priority_wrapper<smf::wal::tx_put_request> {
   const uint32_t           runner_core;
   const std::set<uint32_t> partition_view;
 
-  static bool validate(const wal_write_request &r);
+  static bool valid(const wal_write_request &r);
 };
 
+// FIXME(agallego) use wal_ptid.h in the write-reply
 
 /// \brief exposes a nested hashing for the underlying map
 class wal_write_reply {

--- a/src/filesystem/wal_topics_manager.cc
+++ b/src/filesystem/wal_topics_manager.cc
@@ -5,64 +5,40 @@
 #include <memory>
 #include <utility>
 
+#include <sys/sdt.h>
+
 #include <core/reactor.hh>
 
-
 namespace smf {
-using ptr_t = seastar::lw_shared_ptr<wal_partition_manager>;
 
+wal_topics_manager::wal_topics_manager(wal_opts o) : opts(o) {}
 
-partition_manager_list::partition_manager_list(const wal_opts &        o,
-                                               const seastar::sstring &t)
-  : topic(t), opts(o) {}
-
-seastar::future<ptr_t>
-partition_manager_list::get_manager(uint32_t partition) {
-  if (pmanagers_.find(partition) == pmanagers_.end()) {
-    return serialize_open_.wait(1)
-      .then([this, partition] {
-        if (pmanagers_.find(partition) == pmanagers_.end()) {
-          auto p = seastar::make_lw_shared<wal_partition_manager>(opts, topic,
-                                                                  partition);
-          return p->open().then([this, partition, p] {
-            // must return when fully open - otherwise you get data races
-            pmanagers_.insert({partition, p});
-            return seastar::make_ready_future<ptr_t>(p);
-          });
-        } else {
-          return seastar::make_ready_future<ptr_t>(pmanagers_.at(partition));
-        }
-      })
-      .finally([this] { serialize_open_.signal(1); });
+seastar::future<wal_partition_manager *>
+wal_topics_manager::get_manager(seastar::sstring topic, uint32_t partition) {
+  using ptr = wal_partition_manager *;
+  wal_ptid idx(topic, partition);
+  auto     it = mngrs_.find(idx);
+  if (it == mngrs_.end()) {
+    return seastar::with_semaphore(serialize_open_, 1, [
+      this, topic, partition, idx = std::move(idx)
+    ]() mutable {
+      auto it2 = mngrs_.find(idx);
+      if (it2 != mngrs_.end()) {
+        return seastar::make_ready_future<ptr>(it2->second.get());
+      }
+      auto x = std::make_unique<wal_partition_manager>(opts, topic, partition);
+      auto y = x.get();
+      return y->open().then(
+        [ this, y, x = std::move(x), idx = std::move(idx) ]() mutable {
+          DTRACE_PROBE1(smf, partition_manager_create, idx.id());
+          mngrs_.emplace(std::move(idx), std::move(x));
+          return seastar::make_ready_future<ptr>(y);
+        });
+    });  // end semaphore
   }
-  return seastar::make_ready_future<ptr_t>(pmanagers_.at(partition));
-}
-seastar::future<>
-partition_manager_list::close() {
-  return seastar::do_for_each(pmanagers_.begin(), pmanagers_.end(),
-                              [](auto &pm) { return pm.second->close(); });
-}
-
-wal_topics_manager::wal_topics_manager(const wal_opts &o) : opts(o) {}
-
-seastar::future<ptr_t>
-wal_topics_manager::get_manager(const seastar::sstring &topic,
-                                uint32_t                partition) {
-  if (mngrs_.find(topic) == mngrs_.end()) {
-    return serialize_open_.wait(1)
-      .then([this, topic, partition] {
-        if (mngrs_.find(topic) == mngrs_.end()) {
-          auto p = seastar::make_lw_shared<partition_manager_list>(opts, topic);
-          auto raw = p.get();
-          return raw->get_manager(partition).finally([
-            this, topic, p = std::move(p)
-          ]() mutable { mngrs_.emplace(topic, std::move(p)); });
-        }
-        return mngrs_.at(topic)->get_manager(partition);
-      })
-      .finally([this] { serialize_open_.signal(1); });
-  }
-  return mngrs_.at(topic)->get_manager(partition);
+  DTRACE_PROBE1(smf, partition_manager_get, idx.id());
+  ptr x = it->second.get();
+  return seastar::make_ready_future<ptr>(x);
 }
 seastar::future<>
 wal_topics_manager::close() {

--- a/src/filesystem/wal_topics_manager.h
+++ b/src/filesystem/wal_topics_manager.h
@@ -3,50 +3,29 @@
 #pragma once
 
 #include <memory>
-#include <unordered_map>
 
 #include <core/shared_ptr.hh>
 
+#include "adt/flat_hash_map.h"
 #include "filesystem/wal_opts.h"
 #include "filesystem/wal_partition_manager.h"
+#include "filesystem/wal_ptid.h"
 #include "platform/macros.h"
 
 namespace smf {
-
-class partition_manager_list {
- public:
-  partition_manager_list(const wal_opts &o, const seastar::sstring &t);
-
-  seastar::future<seastar::lw_shared_ptr<smf::wal_partition_manager>>
-                    get_manager(uint32_t partition);
-  seastar::future<> close();
-
-  const seastar::sstring topic;
-  const wal_opts &       opts;
-
-  SMF_DISALLOW_COPY_AND_ASSIGN(partition_manager_list);
-
- private:
-  std::unordered_map<uint32_t, seastar::lw_shared_ptr<wal_partition_manager>>
-                     pmanagers_{};
-  seastar::semaphore serialize_open_{1};
-};
-
 class wal_topics_manager {
  public:
-  explicit wal_topics_manager(const wal_opts &o);
+  explicit wal_topics_manager(wal_opts o);
 
-  seastar::future<seastar::lw_shared_ptr<wal_partition_manager>> get_manager(
-    const seastar::sstring &topic, uint32_t partition);
+  seastar::future<wal_partition_manager *> get_manager(seastar::sstring topic,
+                                                       uint32_t partition);
 
   seastar::future<> close();
-  const wal_opts &  opts;
+  wal_opts          opts;
   SMF_DISALLOW_COPY_AND_ASSIGN(wal_topics_manager);
 
  private:
-  std::unordered_map<seastar::sstring,
-                     seastar::lw_shared_ptr<partition_manager_list>>
-                     mngrs_;
+  smf::flat_hash_map<wal_ptid, std::unique_ptr<wal_partition_manager>> mngrs_;
   seastar::semaphore serialize_open_{1};
 };
 

--- a/src/filesystem/wal_write_behind_cache.cc
+++ b/src/filesystem/wal_write_behind_cache.cc
@@ -3,6 +3,8 @@
 
 #include "filesystem/wal_write_behind_cache.h"
 
+#include <sys/sdt.h>
+
 #include <core/metrics.hh>
 #include <core/sstring.hh>
 
@@ -10,6 +12,24 @@
 #include "platform/log.h"
 
 namespace smf {
+
+struct get_lower_functor {
+  bool
+  operator()(const uint64_t &                            offset,
+             const wal_write_behind_cache::eviction_key &kk) {
+    return offset < kk.key;
+  }
+  bool
+  operator()(const wal_write_behind_cache::eviction_key &kk,
+             const uint64_t &                            offset) {
+    return kk.key < offset;
+  }
+  bool
+  operator()(const wal_write_behind_cache::eviction_key &x,
+             const wal_write_behind_cache::eviction_key &y) {
+    return x.key < y.key;
+  }
+};
 
 wal_write_behind_cache::wal_write_behind_cache(
   seastar::sstring                    topic_name,
@@ -31,43 +51,44 @@ wal_write_behind_cache::wal_write_behind_cache(
        sm::description("Number of bytes writen to this page cache"))});
 }
 
+
+wal_write_behind_cache::wal_write_behind_cache(
+  wal_write_behind_cache &&o) noexcept
+  : stats_(std::move(o.stats_))
+  , current_size_(o.current_size_)
+  , data_(std::move(o.data_))
+  , metrics_(std::move(o.metrics_)){};
+
 uint64_t
 wal_write_behind_cache::min_offset() {
-  if (keys_.empty()) { return 0; }
-  return keys_[0];
+  if (data_.empty()) { return 0; }
+  return data_.front().key;
 }
 uint64_t
 wal_write_behind_cache::max_offset() {
-  if (keys_.empty()) { return 0; }
-  return keys_[keys_.size() - 1];
+  if (data_.empty()) { return 0; }
+  return data_.back().key;
 }
 void
 wal_write_behind_cache::put(uint64_t offset, item_ptr data) {
-  while (current_size_ + data->on_disk_size() > opts.preallocation_size &&
-         !puts_.empty()) {
-    DLOG_INFO("Deleting data because preallocated cache: {} and current_size: "
-              "{} and req size: {}",
-              opts.preallocation_size, current_size_, data->on_disk_size());
-
-    DLOG_THROW_IF(
-      keys_.empty(),
-      "flat_hash_map of values and std::set of keys are inconsistent");
-    uint64_t k        = keys_[0];
-    auto     map_iter = puts_.find(k);
-    DLOG_THROW_IF(map_iter == puts_.end(), "Could not find offset: {} in cache",
-                  k);
-    // main
-    current_size_ -= map_iter->second->on_disk_size();
-
-    // accoutning
-    puts_.erase(map_iter);
-    std::swap(keys_[0], keys_[keys_.size() - 1]);
-    keys_.pop_back();
+  auto const size_on_disk = data->on_disk_size();
+  auto       predicate    = [this, size_on_disk]() {
+    return current_size_ + size_on_disk > opts.preallocation_size;
+  };
+  if (predicate()) {
+    // compute how many things we are going to evict
+    // take into account the ammount of data to save
+    if (SMF_LIKELY(!data_.empty())) {
+      while (predicate() && !data_.empty()) {
+        DTRACE_PROBE(smf, wal_write_behind_cache_evicting_put);
+        current_size_ -= data_.front().size;
+        data_.pop_front();
+      }
+    }
   }
-  current_size_ += data->on_disk_size();
-  stats_.bytes_written += data->on_disk_size();
-  puts_.emplace(offset, data);
-  keys_.push_back(offset);
+  current_size_ += size_on_disk;
+  stats_.bytes_written += size_on_disk;
+  data_.push_back({offset, size_on_disk, data});
 }
 
 seastar::lw_shared_ptr<wal_read_reply>
@@ -80,21 +101,28 @@ wal_write_behind_cache::get(const wal_read_request &req) {
 
   auto retval = seastar::make_lw_shared<wal_read_reply>(req.req->offset());
 
-  for (auto it = puts_.find(retval->get_consume_offset()); it != puts_.end();
-       it      = puts_.find(retval->get_consume_offset())) {
+  for (auto it =
+         std::lower_bound(data_.begin(), data_.end(),
+                          retval->get_consume_offset(), get_lower_functor{});
+       it != std::end(data_);
+       it =
+         std::lower_bound(data_.begin(), data_.end(),
+                          retval->get_consume_offset(), get_lower_functor{})) {
+    if (it->key != retval->get_consume_offset()) { break; }
+    if (retval->on_wire_size() >= req.req->max_bytes()) { break; }
+
     DLOG_INFO("Getting data: read_offset:{}, size on disk: {}",
               retval->get_consume_offset(), retval->on_wire_size());
 
-    if (retval->on_wire_size() >= req.req->max_bytes()) { break; }
     ++stats_.hits;
-    stats_.bytes_read += it->second->on_disk_size();
+    stats_.bytes_read += it->data->on_disk_size();
     auto f = std::make_unique<wal::tx_get_fragmentT>();
-    f->hdr = std::make_unique<wal::wal_header>(it->second->hdr);
-    f->fragment.resize(it->second->fragment.size());
-    std::copy_n(it->second->fragment.get(), it->second->fragment.size(),
+    f->hdr = std::make_unique<wal::wal_header>(it->data->hdr);
+    f->fragment.resize(it->data->fragment.size());
+    std::copy_n(it->data->fragment.get(), it->data->fragment.size(),
                 f->fragment.begin());
     retval->update_consume_offset(retval->get_consume_offset() +
-                                  it->second->fragment.size() +
+                                  it->data->fragment.size() +
                                   kOnDiskInternalHeaderSize);
     retval->reply()->gets.push_back(std::move(f));
   }


### PR DESCRIPTION
This branch has significant perf improvements. 

1) started w/ actually 2X faster than kafka on the first write - we introduced a big regression (std::sort)
2) flatten the namespace of the cache lookup by creating a wal_ptid.h (partition-topic index) - this gave about 2x improvement combined w/ above
3) We reduced the heap allocations and move to normal stack allocated stuff for wal-partition_manager.h
4) the biggest single factor improvement to a 91x performance improvement over kafka writes was to delete the maps - we have an inherent ordering of offsets - we write it in monotonically increasing order. 

4.a) delete all the idnexes (all maps)
4.b) move to a std::deque

Notes: 

I added a __builtin_prefetch and that had a 2% positive impact on LLC-cache misses