### PR TITLE
install-deps.sh: recognize linuxmint

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -92,7 +92,7 @@ function rpms() {
 
 source /etc/os-release
 case $ID in
-  debian|ubuntu)
+  debian|ubuntu|linuxmint)
     debs
     ;;
 


### PR DESCRIPTION
Script works on Linux Mint fine, we can include it too.