### PR TITLE
go: header build performance and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ src/demo_apps/demo_server
 # tests
 src/integration_tests/*_test
 src/test/*_unit_test
+*.test
 
 # docs
 Doxyfile

--- a/src/go/smf/header_test.go
+++ b/src/go/smf/header_test.go
@@ -1,0 +1,62 @@
+package smf
+
+import (
+	cryptorand "crypto/rand"
+	"io"
+	"math"
+	"math/rand"
+	. "testing"
+
+	"github.com/cespare/xxhash"
+	flatbuffers "github.com/google/flatbuffers/go"
+)
+
+func TestBuildHeader(t *T) {
+	for index := 0; index < 10; index++ {
+		meta := uint32(rand.Intn(65535))
+		sess := uint16(rand.Intn(65535))
+		body := make([]byte, rand.Intn(200))
+		io.ReadFull(cryptorand.Reader, body)
+		hbody := BuildHeader(sess, body, meta)
+		assertEqual(t, 16, len(hbody))
+		hdr := NewHeader(hbody)
+		assertEqual(t, meta, hdr.Meta())
+		assertEqual(t, sess, hdr.Session())
+		assertEqual(t, uint32(len(body)), hdr.Size())
+		checksum := uint32(math.MaxUint32 & xxhash.Sum64(body))
+		assertEqual(t, checksum, hdr.Checksum())
+	}
+}
+
+func BenchmarkBuildHeader(b *B) {
+	meta := uint32(rand.Intn(65535))
+	sess := uint16(rand.Intn(65535))
+	body := make([]byte, rand.Intn(200))
+	checksum := math.MaxUint32 & xxhash.Sum64(body)
+	io.ReadFull(cryptorand.Reader, body)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder := flatbuffers.NewBuilder(32) // [1]
+		res := CreateHeader(builder,
+			0,                 // compression int8,
+			0,                 // bitflags int8,
+			sess,              // session uint16,
+			uint32(len(body)), // size uint32,
+			uint32(checksum),  // checksum uint32,
+			meta,              //	meta uint32
+		)
+		builder.Finish(res)
+		// TODO(crackcomm): builder prepends 4 bytes
+		// the header is the last 16 bytes of message
+		// so I did [^1] 32 bytes allocation anyway
+		// I have no idea why it does that
+		// _ = builder.FinishedBytes()
+	}
+}
+
+func assertEqual(t *T, in, out interface{}) {
+	if in != out {
+		t.Helper()
+		t.Fatalf("expected %v got %v", in, out)
+	}
+}

--- a/src/go/smf/header_utils.go
+++ b/src/go/smf/header_utils.go
@@ -18,7 +18,7 @@ func NewHeader(buf []byte) (hdr *Header) {
 
 // BuildHeader - Builds smf RPC request/response header.
 func BuildHeader(session uint16, body []byte, meta uint32) []byte {
-	builder := flatbuffers.NewBuilder(20) // [1]
+	builder := flatbuffers.NewBuilder(32) // [1]
 	res := CreateHeader(builder,
 		0,                                         // compression int8,
 		0,                                         // bitflags int8,
@@ -30,7 +30,7 @@ func BuildHeader(session uint16, body []byte, meta uint32) []byte {
 	builder.Finish(res)
 	// TODO(crackcomm): builder prepends 4 bytes
 	// the header is the last 16 bytes of message
-	// so I did [^1] 20 bytes allocation anyway
+	// so I did [^1] 32 bytes allocation anyway
 	// I have no idea why it does that
 	return builder.FinishedBytes()[4:]
 }


### PR DESCRIPTION
Once again with `.gitignore` rule ^^

This time I included benchmark (just for one size, removed actual used one to compare them).